### PR TITLE
Several fixes in the projects dependencies

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -34,17 +34,6 @@
 			<artifactId>common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<version>1.4</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.4</version>
-		</dependency>
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
@@ -59,11 +48,6 @@
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
 			<version>2.1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.simpleframework</groupId>
-			<artifactId>simple-xml</artifactId>
-			<version>2.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -35,24 +35,9 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
-			<version>20040616</version>
-		</dependency>
-		<dependency>
 			<groupId>org.locationtech.spatial4j</groupId>
 			<artifactId>spatial4j</artifactId>
 			<version>0.7</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.santuario</groupId>
-			<artifactId>xmlsec</artifactId>
-			<version>2.1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
@@ -63,6 +48,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
 			<version>4.1</version>
-		</dependency>		
+		</dependency>
 	</dependencies>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,16 +24,6 @@
 			<version>2.9.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.3</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.4</version>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -34,16 +34,6 @@
 			<version>2.3</version>
 		</dependency>
 		<dependency>
-			<groupId>org.bouncycastle.bcpkix-jdk15on.1.57.org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.57</version>
-		</dependency>
-		<dependency>
-			<groupId>org.bouncycastle.bcprov-jdk15on.1.57.org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.57</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.4</version>

--- a/gxcryptocommon/pom.xml
+++ b/gxcryptocommon/pom.xml
@@ -30,6 +30,16 @@
 			<version>1.57</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.3</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
 			<version>2.1.2</version>

--- a/gxcryptocommon/pom.xml
+++ b/gxcryptocommon/pom.xml
@@ -20,6 +20,16 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.bouncycastle.bcpkix-jdk15on.1.57.org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk15on</artifactId>
+			<version>1.57</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle.bcprov-jdk15on.1.57.org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk15on</artifactId>
+			<version>1.57</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
 			<version>2.1.2</version>

--- a/gxcryptocommon/pom.xml
+++ b/gxcryptocommon/pom.xml
@@ -25,11 +25,6 @@
 			<version>1.57</version>
 		</dependency>
 		<dependency>
-			<groupId>org.bouncycastle.bcprov-jdk15on.1.57.org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.57</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.3</version>

--- a/gxcryptocommon/pom.xml
+++ b/gxcryptocommon/pom.xml
@@ -20,9 +20,9 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.bouncycastle.bcpkix-jdk15on.1.57.org.bouncycastle</groupId>
+			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.57</version>
+			<version>1.60</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/gxcryptocommon/pom.xml
+++ b/gxcryptocommon/pom.xml
@@ -35,11 +35,6 @@
 			<version>2.3</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.3</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
 			<version>2.1.2</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,21 +39,10 @@
 			<artifactId>javapns</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
 			<version>4.1</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.xml.ws</groupId>
-			<artifactId>jaxws-api</artifactId>
-			<version>2.2.1</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<version>1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.ejb</groupId>
@@ -72,11 +61,6 @@
 			<version>2.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.60</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
 			<version>1.3.2</version>
@@ -85,11 +69,6 @@
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.8.2</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.spullara.mustache.java</groupId>
@@ -158,11 +137,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.simpleframework</groupId>
-			<artifactId>simple-xml</artifactId>
-			<version>2.7.1</version>
-		</dependency>
-		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
 			<version>2.9.0</version>
@@ -176,7 +150,7 @@
 		    <groupId>org.apache.ws.security</groupId>
 		    <artifactId>wss4j</artifactId>
 		    <version>1.6.19</version>
-		</dependency>		
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
1. There were several redundant dependencies in some projects. For instance, if the `common` project declares a dependency on A, the `android` project which depends on `common` should not declare a dependency on A explicitly since it inherits all of `common`'s dependencies including A.
2. There were some dependencies that could be moved to more specific modules. For instance, Bounty Castle dependencies should not be on the `common` module but rather on the `crypto` module (same happened with log4j).
3. There were some unused dependencies and one dependency which was used in two places with different version number.
