### PR TITLE
Add support for Progressive Web Applications

### DIFF
--- a/java/src/main/java/com/genexus/filters/AddResponseHeaderFilter.java
+++ b/java/src/main/java/com/genexus/filters/AddResponseHeaderFilter.java
@@ -1,0 +1,44 @@
+package com.genexus.filters;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AddResponseHeaderFilter implements Filter {
+    private Map<String, String> headers = new LinkedHashMap<String, String>();
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            for (Map.Entry<String, String> header : this.headers.entrySet()) {
+                httpResponse.setHeader(header.getKey(), header.getValue());
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+        for (Enumeration<String> names = filterConfig.getInitParameterNames(); names.hasMoreElements();) {
+            String name = names.nextElement();
+            String value = filterConfig.getInitParameter(name);
+            try {
+                this.headers.put(name, value);
+            } catch (RuntimeException e) {
+                throw new ServletException("Exception processing configuration parameter '" + name + "':'" + value + "'", e);
+            }
+        }
+    }
+
+    public void destroy() {
+    }
+}


### PR DESCRIPTION
This PR adds support for Progressive Web Applications in Java applications.

#### Web application manifest
If a `manifest.json` file (representing the web application manifest) is found in the static content directory, a `<link>` element is added to the head of the served HTML, including the file.

#### Service worker
If a `service-worker.js` file (the service worker) is found in the static content directory, a `<script>` element is added to the head of the server HTML, telling the standard JS library to register the service worker.

#### New `AddResponseHeaderFilter` filter
Also, a new filter is added for allowing setting custom HTTP Headers to the response of the assets served by the servlet container, through the `web.xml` file. This new filter will be used to specify the `"Service-Worker-Allowed"` header in the response of the `service-worker.js` file.
