### PR TITLE
Issue 74526

### DIFF
--- a/common/src/main/java/com/genexus/GXSimpleCollection.java
+++ b/common/src/main/java/com/genexus/GXSimpleCollection.java
@@ -1128,6 +1128,10 @@ public class GXSimpleCollection<T> extends Vector<T> implements Serializable, IG
 					{
 						currObj = new Double(jsonArr.getDouble(i));
 					}
+					else if (elementsType == java.math.BigDecimal.class)
+					{
+						currObj = java.math.BigDecimal.valueOf(jsonArr.getDouble(i));
+					}
 					else if (elementsType == Long.class)
 					{
 						currObj = new Long(jsonArr.getLong(i));


### PR DESCRIPTION
After fromXML is called BigDecimal Collection converts internal values to Double.
So when we use &collection.Item(1) it gives a runtime error.