### PR TITLE
Issue 74643

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/GXWebObjectStub.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebObjectStub.java
@@ -19,7 +19,7 @@ import com.genexus.security.GXSecurityProvider;
 
 public abstract class GXWebObjectStub extends HttpServlet
 {
-	public static final ILogger logger = LogManager.getLogger(GXWebObjectStub.class);
+	public static ILogger logger = null;
 
 	private static final boolean DEBUG       = DebugFlag.DEBUG;
 
@@ -115,6 +115,7 @@ public abstract class GXWebObjectStub extends HttpServlet
 				ApplicationContext appContext = ApplicationContext.getInstance();
 				appContext.setServletEngine(true);
 				Application.init(gxcfgClass);
+				logger = LogManager.getLogger(GXWebObjectStub.class);
 			}
 			httpContext = new HttpContextWeb(method, req, res, getServletContext());
 			if (DEBUG)

--- a/java/src/main/java/com/genexus/webpanels/GXWebObjectStub.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebObjectStub.java
@@ -115,8 +115,8 @@ public abstract class GXWebObjectStub extends HttpServlet
 				ApplicationContext appContext = ApplicationContext.getInstance();
 				appContext.setServletEngine(true);
 				Application.init(gxcfgClass);
-				logger = LogManager.getLogger(GXWebObjectStub.class);
 			}
+			logger = LogManager.getLogger(GXWebObjectStub.class);
 			httpContext = new HttpContextWeb(method, req, res, getServletContext());
 			if (DEBUG)
 				dumpRequestInfo(httpContext);


### PR DESCRIPTION
If the first object that was called after the webapp was started was GXOAuthAccessToken a nullpointer excpetion was throwed when the logger was initialized