### PR TITLE
The environment variable to replace the config entries was not honori…

### DIFF
--- a/common/src/main/java/com/genexus/util/IniFile.java
+++ b/common/src/main/java/com/genexus/util/IniFile.java
@@ -311,14 +311,13 @@ public class IniFile {
 	private final String ENVVAR_PREFIX = "GX_";
 
 	private String getEnvironmentValue(String section, String key){
-
 		if (section != null && !section.isEmpty() && section != "Client"){
 			for(int i = 0; i < m_invalidChars.length; i++)
 				section = section.replace(m_invalidChars[i], "_");
-			key = section + "_" + ENVVAR_PREFIX + key;
+			key = String.format("%s%s_%s", ENVVAR_PREFIX, section.toUpperCase(), key.toUpperCase());
 		}
 		else
-			key = ENVVAR_PREFIX + key;
+			key = String.format("%s%s", ENVVAR_PREFIX, key.toUpperCase());
 
 		return System.getenv(key);
 	} 


### PR DESCRIPTION
…ng the documentation

If you want to override the setting TMPMEDIA_DIR under the [Client] section you'll have to add an environment variable called GX_TMPMEDIA_DIR
If you want to override the setting JDBC_DRIVER under the [com.testjava|DEFAULT] section, you'll have to add a variable called GX_COM_TESTJAVA_DEFAULT_JDBC_DRIVER
Always start with 'GX_', always in upper case, and always replace any special char ('.', '|') with an underscore ('_')
https://wiki.genexus.com/commwiki/servlet/wiki?39459