### PR TITLE
The configmapping.json feature was not working as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#vscode
+.vscode/
+
 # Maven
 log/
 target/


### PR DESCRIPTION
As stated in the docs (https://wiki.genexus.com/commwiki/servlet/wiki?39459) the enviroment variable set as the value must be set as stated in the file. No need to add the GX_ prefix or anything.
That's exactly what would happen in the AWS case where they provider their own environment variables (names and values)