### PR TITLE
Limit maven dependency to aws-sdk-s3 instead of full aws-sdk.

### DIFF
--- a/gxexternalproviders/pom.xml
+++ b/gxexternalproviders/pom.xml
@@ -41,8 +41,8 @@
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-			<version>1.11.62</version>
+			<artifactId>aws-java-sdk-s3</artifactId>
+			<version>1.11.570</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.apis</groupId>


### PR DESCRIPTION
Reduced Jar download from 77 to 2.
AWS-SDK Upgrade to lastest version