### PR TITLE
Support download content in offline apps

### DIFF
--- a/android/src/main/java/com/genexus/db/ForEachCursor.java
+++ b/android/src/main/java/com/genexus/db/ForEachCursor.java
@@ -205,7 +205,8 @@ public class ForEachCursor extends Cursor
 	    public void setString(int index, String value) throws SQLException {}
 	    public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName) throws SQLException {}
 	    public void setGXDbFileURI(int index, String fileName, String blobPath, int length) throws SQLException {}
-	    public void setBytes(int index, byte value[]) throws SQLException {}
+		public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName, boolean downloadContent) throws SQLException {}
+		public void setBytes(int index, byte value[]) throws SQLException {}
 	    public void setDateTime(int index, java.util.Date value, boolean onlyTime) throws SQLException {}
 	    public void setDateTime(int index, java.util.Date value, boolean onlyTime, boolean hasmilliseconds) throws SQLException {}
 		public void setDateTime(int index, java.util.Date value, boolean onlyTime, boolean onlyDate, boolean hasmilliseconds) throws SQLException {}
@@ -215,8 +216,9 @@ public class ForEachCursor extends Cursor
 	    public void setTimestamp(int index, java.sql.Timestamp value) throws SQLException {}
 	    public void setBLOBFile(int index, String fileName) throws SQLException {}
 	    public void setBLOBFile(int index, String fileName, boolean isMultiMedia) throws SQLException {}
-	
-	    public void setVarchar(int index, String value, int length, boolean allowsNull) throws SQLException {}
+		public void setBLOBFile(int index, String fileName, boolean isMultiMedia, boolean downloadContent) throws SQLException {}
+
+		public void setVarchar(int index, String value, int length, boolean allowsNull) throws SQLException {}
 	    public void setLongVarchar(int index, String value, boolean allowsNull) throws SQLException {}
 	    public void setNLongVarchar(int index, String value, boolean allowsNull) throws SQLException {}
 	    public void setLongVarchar(int index, String value, int maxLength, boolean allowsNull) throws SQLException {}

--- a/android/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
+++ b/android/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
@@ -727,10 +727,15 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 
 	public void setGXDbFileURI(int index, String fileName, String blobPath, int length) throws SQLException
 	{
-		setGXDbFileURI(index, fileName, blobPath, length, null, null);
+		setGXDbFileURI(index, fileName, blobPath, length, null, null, false);
 	}
 
-    public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName) throws SQLException
+	public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName) throws SQLException
+	{
+		setGXDbFileURI(index, fileName, blobPath, length, null, null, false);
+	}
+
+	public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName, boolean downloadContent) throws SQLException
     {
     	if (blobPath.trim().length() == 0)
     		setVarchar(index, fileName, length, false);
@@ -799,7 +804,9 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 						}
 					}
 					
-					if (isLocalFile)
+					if (isLocalFile
+						|| (downloadContent && (blobPath.toLowerCase().startsWith("http://") || blobPath.toLowerCase().startsWith("https://")) )
+					)
 					{
 						// Local path in sdcard.
 						//fileNameNew = blobBasePath + "/" + GXutil.getFileName(fileName)+ "." + GXutil.getFileType(fileName);
@@ -1113,10 +1120,15 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 
 	public void setBLOBFile(int index, String fileName) throws SQLException
 	{
-		setBLOBFile(index, fileName, false);
+		setBLOBFile(index, fileName, false, false);
 	}
 
-    public void setBLOBFile(int index, String fileName, boolean isMultiMedia) throws SQLException
+	public void setBLOBFile(int index, String fileName, boolean isMultiMedia) throws SQLException
+	{
+		setBLOBFile(index, fileName, isMultiMedia, false);
+	}
+
+	public void setBLOBFile(int index, String fileName, boolean isMultiMedia, boolean downloadContent) throws SQLException
 	{
 		if(skipSetBlobs)
 		{
@@ -1174,10 +1186,11 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 					// add token if necesary?
 					//Boolean addToken = (fileName.compareTo(GXDbFile.removeTokenFromFileName(fileName)) == 0);
 										
-					if (fileName.toLowerCase().startsWith("http") && isLocalFile)
+					if ( (fileName.toLowerCase().startsWith("http://")  || fileName.toLowerCase().startsWith("https://"))
+						&& isLocalFile || downloadContent)
 					{
 						URL fileURL = new URL(fileName);
-						
+
 						//fileNameNew = GXDbFile.generateUri(fileName, addToken);
 						fileNameNew = blobBasePath + "/" + CommonUtil.getFileName(fileName)+ "." + CommonUtil.getFileType(fileName);
 						//fileName = com.genexus.PrivateUtilities.getTempFileName(blobPath, GXutil.getFileName(fileName), GXutil.getFileType(fileName));

--- a/common/src/main/java/com/genexus/db/IFieldSetter.java
+++ b/common/src/main/java/com/genexus/db/IFieldSetter.java
@@ -21,9 +21,10 @@ public interface IFieldSetter
     public void setLongVarchar(int index, String value, int maxLength) throws SQLException;
     public void setString(int index, String value, int length) throws SQLException;
     public void setString(int index, String value) throws SQLException;
-    public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName) throws SQLException;
     public void setGXDbFileURI(int index, String fileName, String blobPath, int length) throws SQLException;
-    public void setBytes(int index, byte value[]) throws SQLException;
+	public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName) throws SQLException;
+	public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName, boolean downloadContent) throws SQLException;
+	public void setBytes(int index, byte value[]) throws SQLException;
     public void setDateTime(int index, java.util.Date value, boolean onlyTime) throws SQLException;
     public void setDateTime(int index, java.util.Date value, boolean onlyTime, boolean hasmilliseconds) throws SQLException;
     public void setDateTime(int index, java.util.Date value, boolean onlyTime, boolean onlyDate, boolean hasmilliseconds) throws SQLException;
@@ -33,6 +34,7 @@ public interface IFieldSetter
     public void setTimestamp(int index, java.sql.Timestamp value) throws SQLException;
     public void setBLOBFile(int index, String fileName) throws SQLException;
     public void setBLOBFile(int index, String fileName, boolean isMultiMedia) throws SQLException;
+	public void setBLOBFile(int index, String fileName, boolean isMultiMedia, boolean downloadContent) throws SQLException;
 
     public void setVarchar(int index, String value, int length, boolean allowsNull) throws SQLException;
     public void setLongVarchar(int index, String value, boolean allowsNull) throws SQLException;

--- a/java/src/main/java/com/genexus/db/ForEachCursor.java
+++ b/java/src/main/java/com/genexus/db/ForEachCursor.java
@@ -313,7 +313,8 @@ public class ForEachCursor extends Cursor implements IForEachCursor
 	    public void setString(int index, String value) throws SQLException {}
 	    public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName) throws SQLException {}
 	    public void setGXDbFileURI(int index, String fileName, String blobPath, int length) throws SQLException {}
-	    public void setBytes(int index, byte value[]) throws SQLException {}
+		public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName, boolean downloadContent) throws SQLException {}
+		public void setBytes(int index, byte value[]) throws SQLException {}
 
 		public void setDateTime(int index, java.util.Date value, boolean onlyTime) throws SQLException {}
 		public void setDateTime(int index, java.util.Date value, boolean onlyTime, boolean hasmilliseconds) throws SQLException{}
@@ -325,8 +326,9 @@ public class ForEachCursor extends Cursor implements IForEachCursor
 	    public void setTimestamp(int index, java.sql.Timestamp value) throws SQLException {}
 	    public void setBLOBFile(int index, String fileName) throws SQLException {}
 	    public void setBLOBFile(int index, String fileName, boolean isMultiMedia) throws SQLException {}
-	
-	    public void setVarchar(int index, String value, int length, boolean allowsNull) throws SQLException {}
+		public void setBLOBFile(int index, String fileName, boolean isMultiMedia, boolean downloadContet) throws SQLException {}
+
+		public void setVarchar(int index, String value, int length, boolean allowsNull) throws SQLException {}
 	    public void setLongVarchar(int index, String value, boolean allowsNull) throws SQLException {}
 	    public void setNLongVarchar(int index, String value, boolean allowsNull) throws SQLException {}
 	    public void setLongVarchar(int index, String value, int maxLength, boolean allowsNull) throws SQLException {}

--- a/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
+++ b/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
@@ -927,6 +927,12 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
     {
 		setGXDbFileURI(index, fileName, blobPath, length, null, null);
 	}
+
+	public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName, boolean downloadContent) throws SQLException
+	{
+		setGXDbFileURI(index, fileName, blobPath, length, tableName, fieldName);
+	}
+
     public void setGXDbFileURI(int index, String fileName, String blobPath, int length, String tableName, String fieldName) throws SQLException
     {
 		 
@@ -1347,6 +1353,11 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 	public void setBLOBFile(int index, String fileName) throws SQLException
 	{
 		setBLOBFile(index, fileName, false);
+	}
+
+	public void setBLOBFile(int index, String fileName, boolean isMultiMedia, boolean downloadContent) throws SQLException
+	{
+		setBLOBFile(index, fileName, isMultiMedia);
 	}
 
     public void setBLOBFile(int index, String fileName, boolean isMultiMedia) throws SQLException


### PR DESCRIPTION
Add suppport for property "Download content in offline apps".

Add new overload to methods setBlobFile y setGxDbFileURI to take in account this new  property.
Implement in Android , to do the download if property is true. 
In Java web  ignore this parameter.

Issue [#57791](https://issues.genexus.com/viewissue.aspx?57791)
