### PR TITLE
Enable support for TLS1.1 and TLS1.2 in Android 4.x

### DIFF
--- a/android/src/main/java/com/genexus/specific/android/HttpClient.java
+++ b/android/src/main/java/com/genexus/specific/android/HttpClient.java
@@ -1,5 +1,7 @@
 package com.genexus.specific.android;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
 
 import com.genexus.CommonUtil;
@@ -7,6 +9,8 @@ import com.genexus.common.interfaces.IExtensionHttpClient;
 import com.genexus.util.GXFile;
 
 import HTTPClient.HTTPConnection;
+
+import javax.net.ssl.SSLSocket;
 
 
 public class HttpClient implements IExtensionHttpClient {
@@ -66,4 +70,23 @@ public class HttpClient implements IExtensionHttpClient {
 		
 	}
 
+	@Override
+	public void prepareSSLSocket(SSLSocket socket) {
+		// enable TLSv1.1/1.2 if available
+		// (see https://github.com/rfc2822/davdroid/issues/229)
+		String[] supportedProtocols = socket.getSupportedProtocols();
+		ArrayList<String> tempList =  new ArrayList<String>();
+		Collections.addAll(tempList, supportedProtocols);
+		// remove only olds and unsecure protocols (SSLv3 ), TLS in all version are supported.
+		tempList.remove("SSLv3");
+		// from : https://blog.dev-area.net/2015/08/13/android-4-1-enable-tls-1-1-and-tls-1-2/
+		//  add 1.1 and 1.2 if not yet added, at least in Android 4.x
+		if (!tempList.contains("TLSv1.1"))
+			tempList.add("TLSv1.1");
+		if (!tempList.contains("TLSv1.2"))
+			tempList.add("TLSv1.2");
+
+		supportedProtocols = tempList.toArray(new String[tempList.size()]);
+		socket.setEnabledProtocols(supportedProtocols);
+	}
 }

--- a/common/src/main/java/HTTPClient/JSSESSLConnection.java
+++ b/common/src/main/java/HTTPClient/JSSESSLConnection.java
@@ -1,6 +1,8 @@
 
 package HTTPClient;
 
+import com.genexus.common.interfaces.SpecificImplementation;
+
 import java.net.*;
 import java.io.IOException;
 
@@ -23,7 +25,9 @@ public class JSSESSLConnection implements ISSLConnection
 
     public Socket processSSLSocket(Socket fromSocket, String host, int port) throws IOException
     {
-		SSLSocket sock = (SSLSocket)sslFactory.createSocket(fromSocket, host, port, true);		
+		SSLSocket sock = (SSLSocket)sslFactory.createSocket(fromSocket, host, port, true);
+		if (SpecificImplementation.HttpClient != null)
+			SpecificImplementation.HttpClient.prepareSSLSocket( sock);
 		return sock;
     }
 
@@ -86,7 +90,7 @@ public class JSSESSLConnection implements ISSLConnection
      */
     public SSLSocketFactory getSSLSocketFactory()
     {
-	return sslFactory;
+		return sslFactory;
     }
 }	
 

--- a/common/src/main/java/com/genexus/common/interfaces/IExtensionHttpClient.java
+++ b/common/src/main/java/com/genexus/common/interfaces/IExtensionHttpClient.java
@@ -1,5 +1,6 @@
 package com.genexus.common.interfaces;
 
+import javax.net.ssl.SSLSocket;
 import java.util.Hashtable;
 
 
@@ -13,5 +14,7 @@ public interface IExtensionHttpClient {
 	String beforeAddFile(String fileName);
 
 	void initializeHttpClient(Object client);
+
+	void prepareSSLSocket(SSLSocket sock);
 
 }

--- a/java/src/main/java/com/genexus/specific/java/HttpClient.java
+++ b/java/src/main/java/com/genexus/specific/java/HttpClient.java
@@ -5,6 +5,8 @@ import java.util.Hashtable;
 import com.genexus.CommonUtil;
 import com.genexus.common.interfaces.IExtensionHttpClient;
 
+import javax.net.ssl.SSLSocket;
+
 public class HttpClient implements IExtensionHttpClient {
 
 	@Override
@@ -29,4 +31,8 @@ public class HttpClient implements IExtensionHttpClient {
 		
 	}
 
+	@Override
+	public void prepareSSLSocket(SSLSocket sock) {
+
+	}
 }


### PR DESCRIPTION
### Problema

In Android 4.x at least support for TLS1.1 y TLS1.2 is disabled by default
Issue [#76039](https://issues.genexus.com/viewissue.aspx?76039)

### Solución

Enable support for TLS1.1 and TLS1.2 if not already enabled
follow this articule, enable this protocols that are disabled by default.

https://blog.dev-area.net/2015/08/13/android-4-1-enable-tls-1-1-and-tls-1-2/