### PR TITLE
Issue: 76353

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/GXWebPanel.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebPanel.java
@@ -702,7 +702,7 @@ public abstract class GXWebPanel extends GXWebObjectBase
 				Class fieldType = field.getType();
 				if (fieldType != null)
 				{
-					if (fieldType.getSuperclass() == GXSimpleCollection.class || fieldType.getSuperclass() == java.util.Vector.class)
+					if ( fieldType.getSuperclass() == GXBaseCollection.class || fieldType.getSuperclass() == GXSimpleCollection.class || fieldType.getSuperclass() == java.util.Vector.class)
 						SetCollectionFieldValue(fieldName, values);
 					else
 						SetFieldValue( targetVar, fieldName, value);


### PR DESCRIPTION
When a BC Collection is in a webpanel form, if an event is executed in the server the BC Collection variable is empty