### PR TITLE
Fix crash when setNull an image in a BC with Download Content in True

### DIFF
--- a/android/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
+++ b/android/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
@@ -1186,8 +1186,8 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 					// add token if necesary?
 					//Boolean addToken = (fileName.compareTo(GXDbFile.removeTokenFromFileName(fileName)) == 0);
 										
-					if ( (fileName.toLowerCase().startsWith("http://")  || fileName.toLowerCase().startsWith("https://"))
-						&& isLocalFile || downloadContent)
+					if ( (fileName.toLowerCase().startsWith("http://") || fileName.toLowerCase().startsWith("https://"))
+						&& (isLocalFile || downloadContent))
 					{
 						URL fileURL = new URL(fileName);
 


### PR DESCRIPTION
**Problema**
Cuando se tiene una imagen en un BC con `Download Content` en `True` se cae cuando la imagen es del filesystem.

En la función que asigna el blobfile, en la linea del arreglo, con que solo se tuviera `downloadContent` en `true` iba por el camino para descargarlo, eso trataba de cargar el `fileName` como una `URL` que antes se le saco el `file://` por lo que ya no es más válida como `URL` y por eso daba `MalformedURLException`

_Crash al asignar un Image
Issue [76584](https://issues.genexus.com/viewissue.aspx?76584)

**Solución**
Que se fije que siempre sea http/https para considerarlo que lo tiene que descargar, independiente de si es `downloadContent`.