### PR TITLE
Issue: 75559

### DIFF
--- a/java/src/main/java/com/genexus/GXDbFile.java
+++ b/java/src/main/java/com/genexus/GXDbFile.java
@@ -113,7 +113,10 @@ public class GXDbFile
 	{
 		String name = getFileName(file);
 		String type = getFileType(file);
-		name = PrivateUtilities.encodeFileName(name);
+		if (file.toLowerCase().startsWith("http://") || file.toLowerCase().startsWith("https://"))
+		{
+			name = PrivateUtilities.encodeFileName(name);
+		}
 		name = PrivateUtilities.checkFileNameLength(file.replace(name, ""), name, type);
 				
 		if (!addScheme)

--- a/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
+++ b/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
@@ -944,7 +944,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
     	else
     	{
 			String fileUri = "";
-			if (fileName.trim().length() != 0)
+			if (fileName.trim().length() != 0 && !(blobPath.startsWith(com.genexus.Preferences.getDefaultPreferences().getMultimediaPath()) && ((fileName.toLowerCase().startsWith("http://") || fileName.toLowerCase().startsWith("https://")))))
 				fileUri = GXDbFile.generateUri(fileName, !GXDbFile.hasToken(fileName), true);
 			else
 			{


### PR DESCRIPTION
The FileName that is saved in the GXI attribute only needs to be encoded if the FileName is a URL.
If the FileName is a URL and the blobPath indicates that the file is in the PublicTempStorage the FileName that is saved in the GXI attribute must not be encoded.