### PR TITLE
Issue: 76675

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/FileItemCollection.java
+++ b/java/src/main/java/com/genexus/webpanels/FileItemCollection.java
@@ -32,7 +32,7 @@ public class FileItemCollection
                     name = GXDbFile.getFileName(completeFileName) + (type.trim().length() == 0 ? "" : ".") + type;
                     if (Application.getGXServices().get(GXServices.STORAGE_SERVICE) == null)
                     {
-                        name = rootPath + name;
+                        name = rootPath + GXDbFile.generateUri(name, true, false);
                     }
                     else
                     {


### PR DESCRIPTION
When a Blob variable upload a file to the server, the file name must contain a random identifier to avoid conflicts.