### PR TITLE
Fix FromTimeZone GX function, the parameter was't been used

### DIFF
--- a/android/src/main/java/com/genexus/GXutil.java
+++ b/android/src/main/java/com/genexus/GXutil.java
@@ -345,10 +345,9 @@ public final class GXutil
 		return CommonUtil.DateTimeToUTC(value, TimeZone.getDefault());
 	}
 
-
 	public static Date DateTimeToUTC(Date value, TimeZone tz)
 	{
-		return CommonUtil.DateTimeToUTC(value, TimeZone.getDefault());
+		return CommonUtil.DateTimeToUTC(value, tz);
 	}
 
 	public static Date DateTimeFromUTC(Date value)


### PR DESCRIPTION
Pasamos el arreglo que estaba en Java,

When we did the refactoring the implementation of DateTimeToUTC with only one parameter was missed. (#46)
2a1836ece0c048b225a035d52264c10c4603ceb6

No se pasaba el parametro timezone.