### PR TITLE
Issue: 77362

### DIFF
--- a/java/src/main/java/com/genexus/db/DefaultExceptionErrorHandler.java
+++ b/java/src/main/java/com/genexus/db/DefaultExceptionErrorHandler.java
@@ -48,6 +48,10 @@ public class DefaultExceptionErrorHandler
 			if	(context.globals.Gx_eop == ERROPT_CANCEL)
 			{
 				com.genexus.Application.rollback(context, remoteHandle, helper.getDataStoreName(), null);
+				try {
+					helper.getConnectionProvider().getConnection(context, remoteHandle, helper.getDataStoreName(), true, true).setError();
+				}
+				catch (SQLException exc) {}
 				throw new GXRuntimeException(e);
 			}
 		}


### PR DESCRIPTION
When a SQLException is throws we must set an Error in the connection wich the request is using to force to be closed the next time a user ask for a connection to the pool