### PR TITLE
Fix in getBlobPath function

### DIFF
--- a/android/src/main/java/com/genexus/Preferences.java
+++ b/android/src/main/java/com/genexus/Preferences.java
@@ -90,18 +90,13 @@ public class Preferences implements IPreferences {
 	public String getBLOB_PATH() {
 
 		BLOB_PATH = AndroidContext.ApplicationContext.getFilesBlobsApplicationDirectory();
-		/*
-		 * if(BLOB_PATH == null) { String file = ""; BLOB_PATH =
-		 * getProperty("CS_BLOB_PATH", "").trim(); if(!BLOB_PATH.equals("") &&
-		 * !BLOB_PATH.endsWith(File.separator)) { BLOB_PATH += File.separator; }
-		 * if(com.genexus.ApplicationContext.getInstance().isServletEngine()) { try {
-		 * file =
-		 * com.genexus.ApplicationContext.getInstance().getServletEngineDefaultPath();
-		 * if(!file.equals("") && !file.endsWith(File.separator)) { file +=
-		 * File.separator; } }catch(Exception ee) { ; } }
-		 * 
-		 * new File(file + BLOB_PATH).mkdirs(); BLOB_PATH = file + BLOB_PATH; }
-		 */
+
+		// fix blobs path directory, add separator at the end
+		if(!BLOB_PATH.equals("") && !BLOB_PATH.endsWith(File.separator))
+		{
+			BLOB_PATH += File.separator;
+		}
+
 		return BLOB_PATH;
 	}
 

--- a/android/src/main/java/com/genexus/PrivateUtilities.java
+++ b/android/src/main/java/com/genexus/PrivateUtilities.java
@@ -249,8 +249,14 @@ public final class PrivateUtilities
 	{
 		name = name.trim();
 		extension = extension.trim();
-			
-		return baseDir + '/' + name + getTempFileName(extension);
+
+		// fix blobs path directory, add separator at the end
+		if(!baseDir.equals("") && !baseDir.endsWith(File.separator))
+		{
+			baseDir += File.separator;
+		}
+
+		return baseDir + name + getTempFileName(extension);
 	}
 
 	public static String getPackageName(String className)

--- a/android/src/main/java/com/genexus/db/SQLAndroidBlobFileHelper.java
+++ b/android/src/main/java/com/genexus/db/SQLAndroidBlobFileHelper.java
@@ -76,7 +76,7 @@ public class SQLAndroidBlobFileHelper
 			{
 				String blobBasePath = com.genexus.Preferences.getDefaultPreferences().getBLOB_PATH();
 				String fileResourceNameNew = "kbfile_" + imagePath.replace("/", "_");
-				fileResourceNameNew = blobBasePath + "/" + CommonUtil.getFileName(fileResourceNameNew)+ "." + CommonUtil.getFileType(fileResourceNameNew);
+				fileResourceNameNew = blobBasePath + CommonUtil.getFileName(fileResourceNameNew)+ "." + CommonUtil.getFileType(fileResourceNameNew);
 
 				imagePath = fileResourceNameNew;
 			}

--- a/android/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
+++ b/android/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
@@ -796,7 +796,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 							//{
 							// path outside database, should be unique.
 							String fileResourceNameNew = "kbfile_" + blobPath.replace("/", "_");
-							fileResourceNameNew = blobBasePath + "/" + CommonUtil.getFileName(fileResourceNameNew)+ "." + CommonUtil.getFileType(fileResourceNameNew);
+							fileResourceNameNew = blobBasePath + CommonUtil.getFileName(fileResourceNameNew)+ "." + CommonUtil.getFileType(fileResourceNameNew);
 
 							fileNameNew = fileResourceNameNew;
 							file = new File(fileResourceNameNew);
@@ -809,7 +809,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 					)
 					{
 						// Local path in sdcard.
-						//fileNameNew = blobBasePath + "/" + GXutil.getFileName(fileName)+ "." + GXutil.getFileType(fileName);
+						//fileNameNew = blobBasePath + GXutil.getFileName(fileName)+ "." + GXutil.getFileType(fileName);
 						if (fileName !=null && fileName.length()>0)
 							fileNameNew = fileName;
 				
@@ -1192,7 +1192,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 						URL fileURL = new URL(fileName);
 
 						//fileNameNew = GXDbFile.generateUri(fileName, addToken);
-						fileNameNew = blobBasePath + "/" + CommonUtil.getFileName(fileName)+ "." + CommonUtil.getFileType(fileName);
+						fileNameNew = blobBasePath + CommonUtil.getFileName(fileName)+ "." + CommonUtil.getFileType(fileName);
 						//fileName = com.genexus.PrivateUtilities.getTempFileName(blobPath, GXutil.getFileName(fileName), GXutil.getFileType(fileName));
 						
 						AndroidLog.debug("setBLOBFile downloading : "+ fileName + " - " + fileNameNew);
@@ -1213,7 +1213,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 							{
 								// path outside database, should be unique.
 								String fileResourceNameNew = "kbfile_" + fileName.replace("/", "_");
-								fileResourceNameNew = blobBasePath + "/" + CommonUtil.getFileName(fileResourceNameNew)+ "." + CommonUtil.getFileType(fileResourceNameNew);
+								fileResourceNameNew = blobBasePath + CommonUtil.getFileName(fileResourceNameNew)+ "." + CommonUtil.getFileType(fileResourceNameNew);
 
 								// keep reference to new created file.
 								fileNameNew = fileResourceNameNew;
@@ -1267,7 +1267,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 						// path outside database, should be unique.
 						String fileNameNewDb = GXDbFile.addTokenToFileName("binary", fileExtension);
 						//Copy the blob to the database path and keep a reference
-						fileNameNewDb = blobBasePath + "/" + CommonUtil.getFileName(fileNameNewDb)+ "." + CommonUtil.getFileType(fileNameNewDb);
+						fileNameNewDb = blobBasePath + CommonUtil.getFileName(fileNameNewDb)+ "." + CommonUtil.getFileType(fileNameNewDb);
 
 						
 						AndroidLog.debug("setBLOBFile copying : "+ fileNameNew + " - " + fileNameNewDb);

--- a/android/src/main/java/com/genexus/db/driver/GXResultSet.java
+++ b/android/src/main/java/com/genexus/db/driver/GXResultSet.java
@@ -997,11 +997,11 @@ public final class GXResultSet implements ResultSet, com.genexus.db.IFieldGetter
 			String gxdbFileUriFileName = gxdbFileUri;
 			if (gxdbFileUri.startsWith(blobDBFilePrefix))
 			{
-				gxdbFileUriFileName = gxdbFileUri.substring(12);
+				gxdbFileUriFileName = gxdbFileUri.substring(13);
 			}
 			else if (gxdbFileUri.startsWith("./"))
 			{
-				gxdbFileUriFileName = gxdbFileUri.substring(1);
+				gxdbFileUriFileName = gxdbFileUri.substring(2);
 			}
 			
 			// Local path in sdcard. Return path with schema , FC need this now.

--- a/android/src/main/java/com/genexus/util/GXFile.java
+++ b/android/src/main/java/com/genexus/util/GXFile.java
@@ -73,7 +73,7 @@ public class GXFile extends AbstractGXFile {
 				String gxdbFileUriFileName = FileName.substring(blobDBFilePrefix.length());
 
 				// Local path in sdcard.
-				FileName = blobBasePath + File.separator + gxdbFileUriFileName;
+				FileName = blobBasePath + gxdbFileUriFileName;
 			} else if (!FileName.contains(File.separator)) // check if its a relative path.
 			{
 				// is a relative path, add app root


### PR DESCRIPTION
### Problem

When creating path for temporary blob file the path was calculate wrong. 
A long time error from rev 57996, July 2012
The function getBLOB_PATH do not have a file separator and it should have it.

Issue [#77477](https://issues.genexus.com/viewissue.aspx?77477)
Issue [#53913](https://issues.genexus.com/viewissue.aspx?53913)

### Solution

Add separator at the en in the getBlobPath function if not include it.
Now getBLOB_PATH has a path separator in the end, so is not necesary to add everywhere.
Fix issue with  fromBase64String() that create a wrong path.
