### PR TITLE
Improved support for OData response codes. Issue 77634

### DIFF
--- a/gxodata/src/main/java/com/genexus/db/odata/ModelInfo.java
+++ b/gxodata/src/main/java/com/genexus/db/odata/ModelInfo.java
@@ -20,7 +20,7 @@ public class ModelInfo
 {
     private static final HashMap<String, ModelInfo> serviceModels = new HashMap<>();
 
-    static ModelInfo getModel(String connUrl)
+	static ModelInfo getModel(String connUrl)
     {
         return serviceModels.get(connUrl);
     }
@@ -34,6 +34,8 @@ public class ModelInfo
     final Edm model;
     boolean useChunked;
 	ContentType defaultContentType = ContentType.JSON_FULL_METADATA;
+	HashSet<String> recordNotFoundServiceCodes;
+	HashSet<String> recordAlreadyExistsServiceCodes;
 
     HttpClientFactory handlerFactory = null;
     ModelInfo(String url, Edm model, String checkOptimisticConcurrency)

--- a/gxodata/src/main/java/com/genexus/db/odata/ODataPreparedStatement.java
+++ b/gxodata/src/main/java/com/genexus/db/odata/ODataPreparedStatement.java
@@ -164,6 +164,11 @@ class ODataPreparedStatement extends ServicePreparedStatement
         {
             switch(ex.getStatusLine().getStatusCode())
             {
+				case 400:
+				{
+					ServiceError serviceError = ((ODataConnection)getConnection()).getServiceError(ex.getODataError().getCode());
+					throw new SQLException(ex.getMessage(), serviceError.getSqlState(), serviceError.getCode(), ex);
+				}
                 case 404: resCode = 404; break;
                 default:  throw new SQLException(ex.getMessage(), ServiceError.INVALID_QUERY.getSqlState(), ServiceError.INVALID_QUERY.getCode(), ex);
             }


### PR DESCRIPTION
- Improved support for OData service-defined error codes
Whenever an HTTP error 400 occurs (bad request) the JSon response contains an error code (which varies from service to service).
Two new properties are defined for the datastore settings (values are a list of comma separated error codes):
- RecordNotFoundServiceCodes=code1,code2,...,codeN
- RecordAlreadyExistsServiceCodes=code1,code2,...,codeN

Upon obtaining an HTTP 400 error we check against this list to see if we should take the response as a "record not found" or "record already exist" DBMS code.

- Sap B1 services return a bad formed json response for the error code so we hack the response to fix it before applying this mappings.