### PR TITLE
Allow uploading empty files with FileUpload user control

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/GXObjectUploadServices.java
+++ b/java/src/main/java/com/genexus/webpanels/GXObjectUploadServices.java
@@ -46,9 +46,6 @@ public class GXObjectUploadServices extends GXWebObjectStub
 							fileName = file.getName();
 
 						long fileSize = file.getSize(); 
-						if (fileSize == 0)
-							continue;
-
 						String ext = CommonUtil.getFileType(fileName);
 						String savedFileName = "";
 						String url = "";


### PR DESCRIPTION
When processing the files uploaded using the FileUpload user control, empty files were ignored.
This behavior is now changed, so empty files can successfully be uploaded.

Issue: 77742
