### PR TITLE
Issue: 78170

### DIFF
--- a/common/src/main/java/com/genexus/internet/HttpClient.java
+++ b/common/src/main/java/com/genexus/internet/HttpClient.java
@@ -377,6 +377,10 @@ public class HttpClient
 		{
             if(hostChanged) // Si el host cambio, creo una nueva instancia de HTTPConnection
             {
+				if (con != null)
+				{
+					con.stop();
+				}
             		if (secure == 1 && port == 80)
             		{
             			port = 443;


### PR DESCRIPTION
A TCP conecction can remaind open if more than one GET using URL was made using HTTPClient
This was a case that was discovered in the Tienda Inglesa KB