### PR TITLE
Call toJSonString with no state for BC

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/GXWebObjectBase.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebObjectBase.java
@@ -564,7 +564,7 @@ public abstract class GXWebObjectBase implements IErrorHandler, GXInternetConsta
 	    		}
 	        }
 	        else{
-	        	strValue = (Value instanceof IGxJSONSerializable) ? ((IGxJSONSerializable)Value).toJSonString() : Value.toString();
+	        	strValue = (Value instanceof com.genexus.xml.GXXMLSerializable) ? ((com.genexus.xml.GXXMLSerializable)Value).toJSonString(false) : Value.toString();
 	        }
 		}
 		return strValue;

--- a/java/src/main/java/com/genexus/webpanels/GXWebObjectBase.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebObjectBase.java
@@ -564,7 +564,15 @@ public abstract class GXWebObjectBase implements IErrorHandler, GXInternetConsta
 	    		}
 	        }
 	        else{
-	        	strValue = (Value instanceof com.genexus.xml.GXXMLSerializable) ? ((com.genexus.xml.GXXMLSerializable)Value).toJSonString(false) : Value.toString();
+				if (Value instanceof com.genexus.xml.GXXMLSerializable) {
+					strValue = ((com.genexus.xml.GXXMLSerializable) Value).toJSonString(false);
+				}
+				else if (Value instanceof IGxJSONSerializable) {
+					strValue = ((IGxJSONSerializable) Value).toJSonString();
+				}
+				else {
+					strValue = Value.toString();
+				}
 	        }
 		}
 		return strValue;


### PR DESCRIPTION
State for BC is not relevant for VRO parameters integrity
[issue 78358](https://issues.genexus.com/viewissue.aspx?78358)