### PR TITLE
Issue: 78290

### DIFF
--- a/java/src/main/java/com/genexus/ConfigFileFinder.java
+++ b/java/src/main/java/com/genexus/ConfigFileFinder.java
@@ -12,10 +12,14 @@ public class ConfigFileFinder
 {
 	private static final String cryptoCfg = "crypto.cfg";
 
-	public static IniFile getConfigFile(Class resourceClass, String fileName, Class defaultResourceClass) 
+	public static IniFile getConfigFile(Class resourceClassParm, String fileName, Class defaultResourceClass)
 	{
 		InputStream is 	   = null;
 		InputStream crypto = null;
+
+		Class resourceClass = resourceClassParm;
+		if (ClientContext.getModelContext() != null)
+			resourceClass = ClientContext.getModelContext().getPackageClass();
 		
 		if	(is == null && resourceClass != null)
 		{


### PR DESCRIPTION
WWSD inside a Module was giving error 400 when a insert was executed. The problem was that the program was looking the client.cfg file inside the module's folder 