### PR TITLE
Issue: 78018

### DIFF
--- a/gxoffice/src/main/java/com/genexus/gxoffice/poi/xssf/ExcelCells.java
+++ b/gxoffice/src/main/java/com/genexus/gxoffice/poi/xssf/ExcelCells.java
@@ -157,11 +157,11 @@ public class ExcelCells implements IExcelCells{
                 	  dformat = dformat.substring(0, dformat.indexOf(' '));
                   }
 
-				  CellStyle newStyle = pWorkbook.createCellStyle();
+                  DataFormat df = pWorkbook.createDataFormat();
+                  CellStyle newStyle = stylesCache.getCellStyle(df.getFormat(dformat));
 
 					for (int i=1;i <= cntCells; i++)
 					{
-						DataFormat df = pWorkbook.createDataFormat();
 						CellStyle cellStyle = pCells[i].getCellStyle();
 						copyPropertiesStyle(newStyle, cellStyle);
 						newStyle.setDataFormat(df.getFormat(dformat));						


### PR DESCRIPTION
When Cells.Date is called more than 64500 times dates was not saved in the sheet.
This happens because we was not reusing CellStyles and poi only allow to create 64500 CellStyles