### PR TITLE
Issue: 75990

### DIFF
--- a/android/src/main/java/com/genexus/internet/HttpContextNull.java
+++ b/android/src/main/java/com/genexus/internet/HttpContextNull.java
@@ -360,4 +360,7 @@ public class HttpContextNull extends HttpContext
 	{
 		return dt;
 	}
+
+	public boolean isHttpContextNull() {return true;}
+	public boolean isHttpContextWeb() {return false;}
 }

--- a/common/src/main/java/com/genexus/IHttpContext.java
+++ b/common/src/main/java/com/genexus/IHttpContext.java
@@ -58,6 +58,8 @@ public interface IHttpContext {
 	void webPutSessionValue(String name, long value);
 	void webPutSessionValue(String name, double value);
 
+	boolean isHttpContextNull();
+	boolean isHttpContextWeb();
 
 
 }

--- a/common/src/main/java/com/genexus/ModelContext.java
+++ b/common/src/main/java/com/genexus/ModelContext.java
@@ -154,6 +154,11 @@ public final class ModelContext extends AbstractModelContext
         this.httpContext = httpContext;
         if (this.httpContext!=null)
             this.httpContext.setStaticContentBase(staticContentBase);
+
+		if (((ModelContext)threadModelContext.get()).getHttpContext().isHttpContextNull() && httpContext.isHttpContextWeb())
+		{
+			threadModelContext.set(this);
+		}
     }
 
     public boolean getPoolConnections()

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -341,6 +341,9 @@ public abstract class HttpContext
 	public abstract void ajax_rsp_command_close();
 	public abstract void dispatchAjaxCommands();
 
+	public abstract boolean isHttpContextNull();
+	public abstract boolean isHttpContextWeb();
+
 	public void AddDeferredFrags()
 	{
 		Enumeration<String> vEnum = deferredFragments.elements();

--- a/java/src/main/java/com/genexus/internet/HttpContextNull.java
+++ b/java/src/main/java/com/genexus/internet/HttpContextNull.java
@@ -420,4 +420,7 @@ public class HttpContextNull extends HttpContext implements IHttpContextNull
 	public void getMultimediaValue(String internalName, String[] blobVar, String[] uriVar) { blobVar[0] = ""; uriVar[0] = ""; }
 	public void cleanup() {}
 	public boolean isMultipartContent() { return false; }
+
+	public boolean isHttpContextNull() {return true;}
+	public boolean isHttpContextWeb() {return false;}
 }

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -1447,4 +1447,6 @@ public class HttpContextWeb extends HttpContext {
 		}
 	}
 
+	public boolean isHttpContextNull() {return false;}
+	public boolean isHttpContextWeb() {return true;}
 }


### PR DESCRIPTION
In some situations when a Blob was uploaded the path returned was not rigth.
The problem was that the threadmodelconext has a httpContextNull instead a HttpContextWeb.
The problem was reproduced in a client environment where a class filter was used.