### PR TITLE
-getString method now applies padding without truncation in GXResultSet

### DIFF
--- a/java/src/main/java/com/genexus/db/driver/GXResultSet.java
+++ b/java/src/main/java/com/genexus/db/driver/GXResultSet.java
@@ -273,10 +273,10 @@ public final class GXResultSet implements ResultSet, com.genexus.db.IFieldGetter
 			try
 			{
 				value = result.getString(columnIndex);
-				if	(result.wasNull())
+				if (result.wasNull() || value == null)
 					value = CommonUtil.replicate(" ", length);
 				else
-				 	value = CommonUtil.padr(value, length, " ");
+					value = String.format(String.format("%%-%ds", length), value);
 
 				log(GXDBDebug.LOG_MAX, "getString - value : " + value);
 			}
@@ -289,10 +289,10 @@ public final class GXResultSet implements ResultSet, com.genexus.db.IFieldGetter
 		else
 		{
 			value = result.getString(columnIndex);
-			if	(result.wasNull())
+			if (result.wasNull() || value == null)
 				value = CommonUtil.replicate(" ", length);
 			else
-		   	 	value = CommonUtil.padr(value, length, " ");
+				value = String.format(String.format("%%-%ds", length), value);
 		}
 
 		resultRegBytes += value.length();


### PR DESCRIPTION
the getString method used to apply GX-style padr which truncates data if the length passed is less than the actual data.
This PR changes this behavior so it does not truncate data