### PR TITLE
Java application executed via java command line did not read app.key (Issue 81350)

### DIFF
--- a/common/src/main/java/com/genexus/ResourceReader.java
+++ b/common/src/main/java/com/genexus/ResourceReader.java
@@ -132,6 +132,9 @@ class GetResource implements Runnable
 	 	try
 	 	{
 	 		is = resourceClass.getResourceAsStream(fileName.toLowerCase());
+	 		if (is == null) {
+				is = resourceClass.getClassLoader().getResourceAsStream(fileName.toLowerCase());
+			}
 		}
 	 	catch (SecurityException e)
 	 	{

--- a/java/src/main/java/com/genexus/specific/java/Application.java
+++ b/java/src/main/java/com/genexus/specific/java/Application.java
@@ -120,7 +120,7 @@ public class Application implements IExtensionApplication {
 
 	@Override
 	public Class getConfigurationClass() {
-		return com.genexus.Application.gxCfg.getClass();
+		return com.genexus.Application.gxCfg;
 	}
 
 	@Override


### PR DESCRIPTION
GeneXus could not read embedded application.key file inside the JAR.
When executed via Command Line using java command (not in Tomcat extracted JAR). 
