### PR TITLE
Fix in getRelativeUrl in Android. 

### DIFF
--- a/android/src/main/java/com/genexus/specific/android/GXutil.java
+++ b/android/src/main/java/com/genexus/specific/android/GXutil.java
@@ -109,7 +109,11 @@ public class GXutil implements IExtensionGXutil {
 
 	@Override
 	public String getRelativeURL(String path) {
-		return com.genexus.CommonUtil.getRelativeBlobFile(path);
+		String servletEnginePath = com.genexus.ApplicationContext.getInstance().getServletEngineDefaultPath();
+		if (servletEnginePath!=null && servletEnginePath.length()>0)
+			return com.genexus.CommonUtil.getRelativeBlobFile(path);
+		else
+			return path;
 	}
 
 	@Override


### PR DESCRIPTION
Return existing path if not have servletEnginePath. In Android servletEnginePath not have value and getRelativeURL lost path values.

Issue [80158](https://issues.genexus.com/viewissue.aspx?80158) :

Crash app al seleccionar registro desde foreign key que tiene imagen y que se muestra el atributo en el wwsd Offline
