### PR TITLE
The CloudService properties can now be overridden by environment vari…

### DIFF
--- a/common/src/main/java/com/genexus/util/EnvVarReader.java
+++ b/common/src/main/java/com/genexus/util/EnvVarReader.java
@@ -1,0 +1,30 @@
+package com.genexus.util;
+
+public class EnvVarReader {
+
+    static String[] m_invalidChars = { ".", "|" };
+    static final String ENVVAR_PREFIX = "GX_";
+
+    public static String getEnvironmentValue(String section, String key) {
+        if (section != null && !section.isEmpty() && section != "Client") {
+            for (int i = 0; i < m_invalidChars.length; i++)
+                section = section.replace(m_invalidChars[i], "_");
+            key = String.format("%s%s_%s", ENVVAR_PREFIX, section.toUpperCase(), key.toUpperCase());
+        } else
+            key = String.format("%s%s", ENVVAR_PREFIX, key.toUpperCase());
+
+        return System.getenv(key);
+    }
+
+    public static String getEnvironmentValue(String serviceType, String serviceName, String propertyName) {
+        String envVarName = String.format("%s%s_%s", ENVVAR_PREFIX, serviceType.toUpperCase(), propertyName.toUpperCase());
+        String value = System.getenv(envVarName);
+
+        if (value != null)
+            return value;
+
+        envVarName = String.format("%s%s__%s_%s", ENVVAR_PREFIX, serviceType.toUpperCase(), serviceName.toUpperCase(), propertyName.toUpperCase());
+
+        return System.getenv(envVarName);
+    }
+}

--- a/common/src/main/java/com/genexus/util/IniFile.java
+++ b/common/src/main/java/com/genexus/util/IniFile.java
@@ -169,6 +169,11 @@ public class IniFile {
 				sections.put(actSection, new Section(il.section, properties));
 			} else if (il.typeLine == PROPERTY) // && actSection != null)
 			{
+				String key = getMappedProperty(actSection, il.property);
+				String envValue = EnvVarReader.getEnvironmentValue(actSection, key);
+				if (envValue != null)
+					il.value = envValue;
+
 				properties.put(il.property.toUpperCase(), new Value(PROPERTY, il.property, il.value));
 			} else if (il.typeLine == COMMENT) {
 				ncomment = ncomment + 1;
@@ -289,11 +294,6 @@ public class IniFile {
 
 	private String getPropertyImpl(String section, String key) {
 		String output = null;
-		key = getMappedProperty(section, key);
-		String envVal = getEnvironmentValue(section, key);
-		if (envVal != null && !envVal.isEmpty())
-			return envVal;
-
 		Section sec = (Section) sections.get(section.toUpperCase());
 		Hashtable prop = null;
 		if (sec != null) {
@@ -308,21 +308,6 @@ public class IniFile {
 		}
 		return output;
 	}
-
-	private String[] m_invalidChars = { ".","|" }; 
-	private final String ENVVAR_PREFIX = "GX_";
-
-	private String getEnvironmentValue(String section, String key){
-		if (section != null && !section.isEmpty() && section != "Client"){
-			for(int i = 0; i < m_invalidChars.length; i++)
-				section = section.replace(m_invalidChars[i], "_");
-			key = String.format("%s%s_%s", ENVVAR_PREFIX, section.toUpperCase(), key.toUpperCase());
-		}
-		else
-			key = String.format("%s%s", ENVVAR_PREFIX, key.toUpperCase());
-
-		return System.getenv(key);
-	} 
 
 	private String getMappedProperty(String section, String key){
 		if (getConfMapping() != null && getConfMapping().containsKey(key))

--- a/java/src/main/java/com/genexus/util/GXServices.java
+++ b/java/src/main/java/com/genexus/util/GXServices.java
@@ -125,7 +125,7 @@ public class GXServices {
 			allowMultiple = Boolean.parseBoolean(reader.getValue());
 			reader.read();
 		}
-		GXProperties properties = processProperties(reader);
+		GXProperties properties = processProperties(type, name, reader);
 
 		GXService service = new GXService();
 		service.setName(name);
@@ -141,7 +141,7 @@ public class GXServices {
 		}
 	}
 
-	private GXProperties processProperties(XMLReader reader) {
+	private GXProperties processProperties(String serviceType, String serviceName, XMLReader reader) {
 		short result;
 		GXProperties properties = new GXProperties();
 		reader.read();
@@ -150,6 +150,11 @@ public class GXServices {
 			String name = new String(reader.getValue());
 			result = reader.readType(1, "Value");
 			String value = new String(reader.getValue());
+
+			String envValue = EnvVarReader.getEnvironmentValue(serviceType, serviceName, name);
+			if (envValue != null)
+				value = envValue;
+
 			properties.add(name, value);
 			reader.read();
 			reader.read();


### PR DESCRIPTION
…ables

Also instead of trying to read the environment value on access request, it gets read (and cached) when the application starts. With the old mechanismo we were trying to access the environment variables every time a property value was being asked.

Issue: https://issues.genexus.com/viewissue.aspx?81439