### PR TITLE
Revert "Issue: 81667"

### DIFF
--- a/android/src/main/java/com/genexus/util/GXFile.java
+++ b/android/src/main/java/com/genexus/util/GXFile.java
@@ -608,14 +608,8 @@ public class GXFile extends AbstractGXFile {
 			}
 		}
 		if (lineIterator != null) {
-			try {
-				lineIterator.close();
-				lineIterator = null;
-			}
-			catch (Exception e) {
-				setUnknownError();
-				e.printStackTrace();
-			}
+			lineIterator.close();
+			lineIterator = null;
 		}
 	}
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.2</version>
 		</dependency>		
 		<dependency>
 			<groupId>org.simpleframework</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-fileupload</groupId>
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
-			<version>1.2</version>
+			<version>1.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-net</groupId>
@@ -103,17 +103,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.10.3</version>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.10.3</version>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.10.3</version>
+			<version>2.9.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.apis</groupId>

--- a/java/src/main/java/com/genexus/util/GXFile.java
+++ b/java/src/main/java/com/genexus/util/GXFile.java
@@ -738,12 +738,8 @@ public class GXFile extends AbstractGXFile {
             }
         }
         if (lineIterator != null) {
-        	try {
-				lineIterator.close();
-				lineIterator = null;
-			} catch (Exception e) {
-				setUnknownError(e);
-			}
+            lineIterator.close();
+            lineIterator = null;
         }
     }
 }


### PR DESCRIPTION
> Reverts genexuslabs/JavaClasses#200

El PR #200 que fue mergeado a master está provocando estos crashes en todos los dispositivos Android con API < 23:

```
java.lang.NoSuchMethodError: 
  at org.apache.commons.io.FileUtils.isSymlink (FileUtils.java:3107)
  at org.apache.commons.io.FileUtils.sizeOfDirectory0 (FileUtils.java:2618)
  at org.apache.commons.io.FileUtils.sizeOfDirectory (FileUtils.java:2599)
  at com.fedorvlasov.lazylist.ImageLoader$DiskCache.trimSize (ImageLoader.java:889)
  at com.fedorvlasov.lazylist.ImageLoader.trimCacheSize (ImageLoader.java:689)
  at com.artech.application.MyApplication.clearData (MyApplication.java:316)
  at com.artech.init.AppInitRunnable.run (AppInitRunnable.java:40)
  at java.lang.Thread.run (Thread.java:818)
```

Se migró de Apache Commons IO 2.2 a la versión 2.6, que requiere el package java.nio (introducido en Java 1.7). En Android ese package únicamente está disponible a partir de API 23.

**Este PR hace revert de ese cambio**. Vamos a tener que ver cuando tengamos tiempo cómo integrar la nueva versión de **Apache Commons IO**.

- En Android master va a quedar solucionado al mergear este PR (y correspondiente revert de SVN)
- En el branch de Corona no es necesario hacer cambios, no había entrado este PR al branch beta-corona de las JavaClasses. Hace unos de días habíamos pasado a utilizar erróneamente las JavaClasses master en vez de beta-corona como teníamos inicialmente y ahí entró este cambio que rompió.