### PR TITLE
Fix error uploading Japanese filename to amazon s3

### DIFF
--- a/common/src/main/java/com/genexus/util/StorageUtils.java
+++ b/common/src/main/java/com/genexus/util/StorageUtils.java
@@ -43,4 +43,16 @@ public class StorageUtils {
             return name;
         }
     }
+	public static String encodeNonAsciiCharacters(String value)
+	{
+		StringBuilder b = new StringBuilder();
+		for (char c : value.toCharArray()) {
+			if (c >= 128)
+				b.append("\\u").append(String.format("%04X", (int) c));
+			else
+				b.append(c);
+		}
+		return b.toString();
+	}
+
 }

--- a/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderS3.java
+++ b/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderS3.java
@@ -187,18 +187,6 @@ public class ExternalProviderS3 implements ExternalProvider {
         client.copyObject(request);
         return ((AmazonS3Client) client).getResourceUrl(bucket, newName);
     }
-	String encodeNonAsciiCharacters(String value)
-	{
-		StringBuilder b = new StringBuilder();
-		for (char c : value.toCharArray()) {
-			if (c >= 128)
-				b.append("\\u").append(String.format("%04X", (int) c));
-			else
-				b.append(c);
-		}
-		return b.toString();
-	}
-
     public String copy(String objectUrl, String newName, String tableName, String fieldName, boolean isPrivate) {
         String resourceFolderName = folder + StorageUtils.DELIMITER + tableName + StorageUtils.DELIMITER + fieldName;
         createFolder(resourceFolderName);
@@ -209,7 +197,7 @@ public class ExternalProviderS3 implements ExternalProvider {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.addUserMetadata("Table", tableName);
         metadata.addUserMetadata("Field", fieldName);
-        metadata.addUserMetadata("KeyValue", encodeNonAsciiCharacters(resourceKey));
+        metadata.addUserMetadata("KeyValue", StorageUtils.encodeNonAsciiCharacters(resourceKey));
 
         CopyObjectRequest request = new CopyObjectRequest(bucket, objectUrl, bucket, resourceKey);
         request.setNewObjectMetadata(metadata);


### PR DESCRIPTION
Issue:81508
Amazon S3 stores user-defined metadata keys in lowercase. Each key-value pair must conform to US-ASCII when using REST and UTF-8 when using SOAP or browser-based uploads via POST.