### PR TITLE
Geocode Fails with empty string.

### DIFF
--- a/common/src/main/java/com/genexus/util/GXGeolocation.java
+++ b/common/src/main/java/com/genexus/util/GXGeolocation.java
@@ -170,6 +170,10 @@ public class GXGeolocation
 	public static java.util.Vector<String> getLocation(String address)
 	{
 		java.util.Vector<String> result = new java.util.Vector<>();
+		if(address != null && !address.isEmpty())
+		{
+			return result;
+		}
 		try {
 			
 			String urlString = "https://maps.google.com/maps/api/geocode/json?address=" + URLEncoder.encode(address, "utf-8") + "&sensor=false";

--- a/common/src/main/java/com/genexus/util/GXGeolocation.java
+++ b/common/src/main/java/com/genexus/util/GXGeolocation.java
@@ -170,7 +170,7 @@ public class GXGeolocation
 	public static java.util.Vector<String> getLocation(String address)
 	{
 		java.util.Vector<String> result = new java.util.Vector<>();
-		if(address != null && !address.isEmpty())
+		if(address == null || address.isEmpty())
 		{
 			return result;
 		}


### PR DESCRIPTION
Call to Geocode function did not check for empty string and Crashed . Fixed. Issue 82230