### PR TITLE
Fix RecoverEncryptionKey for ajax parameters

### DIFF
--- a/java/src/main/java/com/genexus/GXutil.java
+++ b/java/src/main/java/com/genexus/GXutil.java
@@ -1186,12 +1186,9 @@ public final class GXutil
   		{
 			return Codecs.decode(s, "UTF8");
 		}
-		catch(  UnsupportedEncodingException e)
+		catch(  UnsupportedEncodingException | IllegalArgumentException e)
 		{
 			return s;
-		}
-  		catch (IllegalArgumentException ie){
-  			return s;
 		}
 	}
 

--- a/java/src/main/java/com/genexus/GXutil.java
+++ b/java/src/main/java/com/genexus/GXutil.java
@@ -1190,6 +1190,9 @@ public final class GXutil
 		{
 			return s;
 		}
+  		catch (IllegalArgumentException ie){
+  			return s;
+		}
 	}
 
 	public static String URLEncode(String s)

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -774,7 +774,7 @@ public abstract class HttpContext
 			if (clientKey != null && clientKey.trim().length() > 0)
 			{
 				boolean candecrypt[]=new boolean[1];
-				clientKey = Encryption.decryptRijndael(Encryption.AJAX_ENCRYPTION_IV + clientKey, Encryption.GX_AJAX_PRIVATE_KEY, candecrypt);
+				clientKey = Encryption.decryptRijndael(Encryption.GX_AJAX_PRIVATE_IV + clientKey, Encryption.GX_AJAX_PRIVATE_KEY, candecrypt);
 				if (candecrypt[0])
 				{
 					webPutSessionValue(Encryption.AJAX_ENCRYPTION_KEY, clientKey);

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -774,7 +774,7 @@ public abstract class HttpContext
 			if (clientKey != null && clientKey.trim().length() > 0)
 			{
 				boolean candecrypt[]=new boolean[1];
-				clientKey = Encryption.decryptRijndael(clientKey, Encryption.GX_AJAX_PRIVATE_KEY, candecrypt);
+				clientKey = Encryption.decryptRijndael(Encryption.AJAX_ENCRYPTION_IV + clientKey, Encryption.GX_AJAX_PRIVATE_KEY, candecrypt);
 				if (candecrypt[0])
 				{
 					webPutSessionValue(Encryption.AJAX_ENCRYPTION_KEY, clientKey);


### PR DESCRIPTION
Issue:82324
AJAX_ENCRYPTION_KEY decryption must add the IV since it is not included in header AJAX_SECURITY_TOKEN.  If IV is not added, AJAX_ENCRYPTION_KEY  cannot be recovered after session timeout occurs. IV is required as a prefix by CBC algorithm used in decryptRijndael.