### PR TITLE
Read PlatformDevice header in order to keep compatibility.

### DIFF
--- a/common/src/main/java/com/genexus/ClientInformation.java
+++ b/common/src/main/java/com/genexus/ClientInformation.java
@@ -68,6 +68,9 @@ public class ClientInformation
 	}
 	static public String getPlatformName()
 	{
-		return SpecificImplementation.Application.getModelContext().getHttpContext().getHeader("PlatformName");
+		String platformName =  SpecificImplementation.Application.getModelContext().getHttpContext().getHeader("PlatformName");
+		if (platformName==null || platformName == "")
+			platformName =  SpecificImplementation.Application.getModelContext().getHttpContext().getHeader("DevicePlatform");
+		return platformName;
 	}
 }

--- a/common/src/main/java/com/genexus/ClientInformation.java
+++ b/common/src/main/java/com/genexus/ClientInformation.java
@@ -69,7 +69,7 @@ public class ClientInformation
 	static public String getPlatformName()
 	{
 		String platformName =  SpecificImplementation.Application.getModelContext().getHttpContext().getHeader("PlatformName");
-		if (platformName==null || platformName == "")
+		if (platformName==null || platformName.isEmpty())
 			platformName =  SpecificImplementation.Application.getModelContext().getHttpContext().getHeader("DevicePlatform");
 		return platformName;
 	}


### PR DESCRIPTION
Issue:60239
Take into consideration both headers: PlatformName and DevicePlatform in order to keep compatibility. PlatformName is the new header. By compatibility DevicePlatform is read when PlatformName is not present.