### PR TITLE
Expression evaluator could throw a StackOverflowError if it has a nes…

### DIFF
--- a/common/src/main/java/com/genexus/util/ExpressionEvaluator.java
+++ b/common/src/main/java/com/genexus/util/ExpressionEvaluator.java
@@ -604,7 +604,7 @@ public class ExpressionEvaluator
 			token += tokenizer.nextToken();
 		}
 		while (!matchParentesis(token) || (token.trim().equals("") && tokenizer.hasMoreTokens()));
-		if (tokenizer.useParentheses() && !token.startsWith("("))
+		if (tokenizer.useParentheses() && !token.startsWith("(") && !token.startsWith("IIF"))
 		{
 			return "(" + token.trim() + ")";
 		}


### PR DESCRIPTION
…ted IIF expression and an AND token

For example IIF(DIR=0,IIF((HIF=0) AND (CLS1 > IND*PAR2),CLS2*PAR1/100,0),0)
Issue:82663