### PR TITLE
Initialize CacheAPI with a default key namespace.

### DIFF
--- a/common/src/main/java/com/genexus/xml/GXXMLSerializable.java
+++ b/common/src/main/java/com/genexus/xml/GXXMLSerializable.java
@@ -557,6 +557,11 @@ public abstract class GXXMLSerializable implements Cloneable, Serializable, IGxJ
 			CommonUtil.ErrorToMessages("fromxml error", ex.getMessage(), messages);
 			return false;
 		}
+		catch (Exception ex)
+		{
+			CommonUtil.ErrorToMessages("fromxml error", ex.getMessage(), messages);
+			return false;
+		}
 	}
 	public String ToJavascriptSource(boolean includeState)
 	{

--- a/java/src/main/java/com/genexus/util/CacheAPI.java
+++ b/java/src/main/java/com/genexus/util/CacheAPI.java
@@ -5,7 +5,7 @@ import com.genexus.ICacheService;
 
 public class CacheAPI 
 {
-	static final String defaultCacheId = "DefaultCache";
+	static final String DEFAULT_CACHE_ID = "DefaultCache";
 
     public static CacheAPI database()
     {
@@ -26,7 +26,7 @@ public class CacheAPI
     
     private String cacheId;
     
-    public CacheAPI() {cacheId = defaultCacheId;}
+    public CacheAPI() {cacheId = DEFAULT_CACHE_ID;}
     
     public CacheAPI(String name)
     {

--- a/java/src/main/java/com/genexus/util/CacheAPI.java
+++ b/java/src/main/java/com/genexus/util/CacheAPI.java
@@ -5,6 +5,8 @@ import com.genexus.ICacheService;
 
 public class CacheAPI 
 {
+	static final String defaultCacheId = "DefaultCache";
+
     public static CacheAPI database()
     {
         return new CacheAPI(CacheFactory.CACHE_DB);
@@ -24,7 +26,7 @@ public class CacheAPI
     
     private String cacheId;
     
-    public CacheAPI() {}
+    public CacheAPI() {cacheId = defaultCacheId;}
     
     public CacheAPI(String name)
     {


### PR DESCRIPTION
Issue: 55786
Fix NullPointerException when accessing CacheAPI without specifying a cache instante.
It is the case of using:
&value = &Cache.Get("TESTKEY")  (which is allowed)
instead of 
&Cache = Cache.GetCache("MyCache")
&value = &Cache.Get("TESTKEY")

That matches behavior of .net.