### PR TITLE
Do not send Close Output Stream exceptions to Web Server log. Use Log4j log instead (Issue:83656)

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -17,7 +17,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.genexus.*;
-import com.genexus.webpanels.HttpContextWeb;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 
@@ -39,7 +38,7 @@ import org.apache.logging.log4j.Logger;
 public abstract class HttpContext 
 		extends HttpAjaxContext implements IHttpContext
 {
-	private static Logger logger = org.apache.logging.log4j.LogManager.getLogger(HttpContextWeb.class);
+	private static Logger logger = org.apache.logging.log4j.LogManager.getLogger(HttpContext.class);
 
     private static String GX_AJAX_REQUEST_HEADER = "GxAjaxRequest";
     private static String GX_SPA_REQUEST_HEADER = "X-SPA-REQUEST";

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.genexus.*;
+import com.genexus.webpanels.HttpContextWeb;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 
@@ -33,11 +34,13 @@ import json.org.json.IJsonFormattable;
 import json.org.json.JSONArray;
 import json.org.json.JSONException;
 import json.org.json.JSONObject;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.logging.log4j.Logger;
 
 public abstract class HttpContext 
 		extends HttpAjaxContext implements IHttpContext
 {
+	private static Logger logger = org.apache.logging.log4j.LogManager.getLogger(HttpContextWeb.class);
+
     private static String GX_AJAX_REQUEST_HEADER = "GxAjaxRequest";
     private static String GX_SPA_REQUEST_HEADER = "X-SPA-REQUEST";
     protected static String GX_SPA_REDIRECT_URL = "X-SPA-REDIRECT-URL";
@@ -848,10 +851,13 @@ public abstract class HttpContext
 			}
 		}        	
 		getResponse().setStatus(statusCode);
-		try { getResponse().sendError(statusCode, statusDescription); }
+		try {
+			getResponse().sendError(statusCode, statusDescription);
+		}
 		catch(Exception e) {
-					System.err.println("E " + e);
-					e.printStackTrace();
+			if (logger.isErrorEnabled()) {
+				logger.error("Could not send Response Error Code", e);
+			}
 		}
 		setAjaxCallMode();
 		disableOutput();
@@ -1410,8 +1416,9 @@ public abstract class HttpContext
 		}
 		catch(IOException e) 
 		{
-			System.err.println("E " + e);
-			e.printStackTrace();
+			if (logger.isDebugEnabled()) {
+				logger.debug("ERROR: When Closing Output Stream.", e);
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue: 83656

The Exception was being send to WebServer Log. 
2020-07-03 08:42:35,296 ERROR [stderr] (default task-9) E java.io.IOException: 接続が相手からリセットされました (translate by Nakamura : Connection was reset from opponent)
2020-07-03 08:42:35,296 ERROR [stderr] (default task-9) java.io.IOException: 接続が相手からリセットされました (translated by Nakamura : Connection was reset from opponent)
2020-07-03 08:42:35,296 ERROR [stderr] (default task-9) at sun.nio.ch.FileDispatcherImpl.writev0(Native Method)
2020-07-03 08:42:35,296 ERROR [stderr] (default task-9) at sun.nio.ch.SocketDispatcher.writev(SocketDispatcher.java:51)
2020-07-03 08:42:35,296 ERROR [stderr] (default task-9) at sun.nio.ch.IOUtil.write(IOUtil.java:148)
2020-07-03 08:42:35,296 ERROR [stderr] (default task-9) at sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:504)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at org.xnio.nio.NioSocketConduit.write(NioSocketConduit.java:162)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.server.protocol.http.HttpResponseConduit.processWrite(HttpResponseConduit.java:258)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.server.protocol.http.HttpResponseConduit.write(HttpResponseConduit.java:632)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.conduits.ChunkedStreamSinkConduit.doWrite(ChunkedStreamSinkConduit.java:163)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.conduits.ChunkedStreamSinkConduit.write(ChunkedStreamSinkConduit.java:127)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.conduits.ChunkedStreamSinkConduit.write(ChunkedStreamSinkConduit.java:216)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at org.xnio.conduits.ConduitStreamSinkChannel.write(ConduitStreamSinkChannel.java:158)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.channels.DetachableStreamSinkChannel.write(DetachableStreamSinkChannel.java:179)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.server.HttpServerExchange$WriteDispatchChannel.write(HttpServerExchange.java:2028)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at org.xnio.channels.Channels.writeBlocking(Channels.java:152)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.servlet.spec.ServletOutputStreamImpl.writeTooLargeForBuffer(ServletOutputStreamImpl.java:194)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at io.undertow.servlet.spec.ServletOutputStreamImpl.write(ServletOutputStreamImpl.java:142)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at com.genexus.filters.ExpiresFilter$XServletOutputStream.write(ExpiresFilter.java:1048)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at java.util.zip.GZIPOutputStream.finish(GZIPOutputStream.java:168)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at java.util.zip.DeflaterOutputStream.close(DeflaterOutputStream.java:238)
2020-07-03 08:42:35,297 ERROR [stderr] (default task-9) at com.genexus.internet.HttpContext.closeOutputStream(HttpContext.java:1403