### PR TITLE
Do not add default port to HttpClient baseURL

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpRequest.java
+++ b/java/src/main/java/com/genexus/internet/HttpRequest.java
@@ -102,7 +102,9 @@ public abstract class HttpRequest implements IHttpRequest
 	
 	public String getBaseURL()
 	{
-		return (getSecure() == 0? "http://": "https://") + getServerHost() + ":" + getServerPort() + getScriptPath();
+		int port = getServerPort();
+		String portS = (port == 80 || port == 443) ? "" : ":" + port;
+		return (getSecure() == 0? "http://": "https://") + getServerHost() + portS + getScriptPath();
 	}
 
 	public void getHeader(String name, long[] value)


### PR DESCRIPTION
Issue: 83454

"BaseURL": "http://real-host/Issue1324MZHJavaEnvironment/"

instead of:

"BaseURL": "http://real-host:80/Issue1324MZHJavaEnvironment/"