### PR TITLE
Add Support for client.cfg.prod and Host Headers by config instead of X-Forwarded-Headers (Issue: 84161)

### DIFF
--- a/common/src/main/java/com/genexus/util/IniFileMultiple.java
+++ b/common/src/main/java/com/genexus/util/IniFileMultiple.java
@@ -1,0 +1,28 @@
+package com.genexus.util;
+
+import java.io.*;
+
+public class IniFileMultiple extends IniFile {
+	private IniFile additionalProperties;
+
+	public IniFileMultiple(InputStream in, InputStream in2) throws IOException {
+		super(in);
+		try {
+			additionalProperties = new IniFile(in2);
+		} catch (Exception e) { }
+	}
+
+	@Override
+	public String getProperty(String section, String key, String defaultValue) {
+		String value = null;
+		if (additionalProperties != null){
+			value = additionalProperties.getProperty(section, key);
+		}
+		if (value == null) {
+			value = super.getProperty(section, key, defaultValue);
+		}
+		return value;
+	}
+
+
+}

--- a/java/src/main/java/com/genexus/ConfigFileFinder.java
+++ b/java/src/main/java/com/genexus/ConfigFileFinder.java
@@ -7,86 +7,27 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.genexus.util.IniFile;
+import com.genexus.util.IniFileMultiple;
 
 public class ConfigFileFinder
 {
-	private static final String cryptoCfg = "crypto.cfg";
+	private static final String CRYPTO_CFG = "crypto.cfg";
+	private static final String PROD_ENV_SUFFIX = ".prod";
 
 	public static IniFile getConfigFile(Class resourceClassParm, String fileName, Class defaultResourceClass)
 	{
-		InputStream is 	   = null;
-		InputStream crypto = null;
+		IniFileStream iniFileStream = new IniFileStream(resourceClassParm, fileName, defaultResourceClass).invoke();
+		InputStream is = iniFileStream.getIs();
+		InputStream crypto = iniFileStream.getCrypto();
 
-		Class resourceClass = resourceClassParm;
-		if (ClientContext.getModelContext() != null)
-			resourceClass = ClientContext.getModelContext().getPackageClass();
-		
-		if	(is == null && resourceClass != null)
-		{
-			is = ResourceReader.getResourceAsStream(resourceClass, fileName);
-			if	(is != null)
-			{
-				crypto = ResourceReader.getResourceAsStream(resourceClass, cryptoCfg);
-			}
-		}
-		
-		// This is for GeneXus programs set where is the .cfg file
-		if	(is == null && defaultResourceClass != null)
-		{
-			is = ResourceReader.getResourceAsStream(defaultResourceClass, fileName);
-			if	(is != null)
-			{
-				crypto = ResourceReader.getResourceAsStream(resourceClass, cryptoCfg);
-			}
-		}																	  
-
-		if	(is == null)
-		{
-				try
-				{
-					is = new BufferedInputStream(new FileInputStream(fileName));
-					if	(is != null)
-					{
-						crypto = new BufferedInputStream(new FileInputStream(cryptoCfg));
-					}
-				}
-				catch (FileNotFoundException e)
-				{
-					try
-					{
-						is = new BufferedInputStream(new FileInputStream(fileName));
-						if	(is != null)
-						{
-							crypto = new BufferedInputStream(new FileInputStream(cryptoCfg));
-						}
-					}
-					catch (FileNotFoundException e2) { ; }
-				}
-		}
-
-		if	(is == null)
-		{
-			if	(ApplicationContext.getInstance().isGXUtility())
-			{
-				try
-				{
-					is = new FileInputStream(fileName);
-					if	(is != null)
-					{
-						crypto = new FileInputStream(fileName);
-					}
-				}
-				catch (IOException e)
-				{
-				}
-			}
-		}
+		IniFileStream iniFileStreamProdEnv = new IniFileStream(resourceClassParm, fileName + PROD_ENV_SUFFIX, defaultResourceClass).invoke();
+		InputStream isProdEnv = iniFileStreamProdEnv.getIs();
 
 		IniFile iniFile = null;
 
 		try
 		{
-			iniFile = new IniFile(is);
+			iniFile = new IniFileMultiple(is, isProdEnv);
 		}
 		catch (IOException e)
 		{
@@ -113,5 +54,98 @@ public class ConfigFileFinder
 		iniFile.setEncryptionStream(crypto);
 
 		return iniFile;
+	}
+
+	private static class IniFileStream {
+		private Class resourceClassParm;
+		private String fileName;
+		private Class defaultResourceClass;
+		private InputStream is;
+		private InputStream crypto;
+
+		public IniFileStream(Class resourceClassParm, String fileName, Class defaultResourceClass) {
+			this.resourceClassParm = resourceClassParm;
+			this.fileName = fileName;
+			this.defaultResourceClass = defaultResourceClass;
+		}
+
+		public InputStream getIs() {
+			return is;
+		}
+
+		public InputStream getCrypto() {
+			return crypto;
+		}
+
+		public IniFileStream invoke() {
+			is = null;
+			crypto = null;
+
+			Class resourceClass = resourceClassParm;
+			if (ClientContext.getModelContext() != null)
+				resourceClass = ClientContext.getModelContext().getPackageClass();
+
+			if	(is == null && resourceClass != null)
+			{
+				is = ResourceReader.getResourceAsStream(resourceClass, fileName);
+				if	(is != null)
+				{
+					crypto = ResourceReader.getResourceAsStream(resourceClass, CRYPTO_CFG);
+				}
+			}
+
+			// This is for GeneXus programs set where is the .cfg file
+			if	(is == null && defaultResourceClass != null)
+			{
+				is = ResourceReader.getResourceAsStream(defaultResourceClass, fileName);
+				if	(is != null)
+				{
+					crypto = ResourceReader.getResourceAsStream(resourceClass, CRYPTO_CFG);
+				}
+			}
+
+			if	(is == null)
+			{
+					try
+					{
+						is = new BufferedInputStream(new FileInputStream(fileName));
+						if	(is != null)
+						{
+							crypto = new BufferedInputStream(new FileInputStream(CRYPTO_CFG));
+						}
+					}
+					catch (FileNotFoundException e)
+					{
+						try
+						{
+							is = new BufferedInputStream(new FileInputStream(fileName));
+							if	(is != null)
+							{
+								crypto = new BufferedInputStream(new FileInputStream(CRYPTO_CFG));
+							}
+						}
+						catch (FileNotFoundException e2) { ; }
+					}
+			}
+
+			if	(is == null)
+			{
+				if	(ApplicationContext.getInstance().isGXUtility())
+				{
+					try
+					{
+						is = new FileInputStream(fileName);
+						if	(is != null)
+						{
+							crypto = new FileInputStream(fileName);
+						}
+					}
+					catch (IOException e)
+					{
+					}
+				}
+			}
+			return this;
+		}
 	}
 }

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -886,7 +886,7 @@ public class HttpContextWeb extends HttpContext {
 			return host;
 		}
 		String serverNameProperty = ModelContext.getModelContext().getPreferences().getProperty("SERVER_NAME", "");
-		if (!serverNameProperty.equals("")) {
+		if (!StringUtils.isBlank(serverNameProperty)) {
 			return serverNameProperty;
 		}
 		if (request != null)
@@ -899,6 +899,10 @@ public class HttpContextWeb extends HttpContext {
 		String port = getHeader("X-Forwarded-Port");
 		if (port.length() > 0){
 			return Integer.parseInt(port);
+		}
+		String serverPortProperty = ModelContext.getModelContext().getPreferences().getProperty("SERVER_PORT", "");
+		if (!StringUtils.isBlank(serverPortProperty)) {
+			return Integer.parseInt(serverPortProperty);
 		}
 		String serverNameProperty = ModelContext.getModelContext().getPreferences().getProperty("SERVER_NAME", "");
 		if (serverNameProperty.indexOf(':') != -1) {
@@ -937,6 +941,11 @@ public class HttpContextWeb extends HttpContext {
 		if (protocol != null && !protocol.equals("")) {
 			return protocol.equalsIgnoreCase("https") ? 1 : 0;
 		}
+		String serverProtocolProperty = ModelContext.getModelContext().getPreferences().getProperty("SERVER_PROTOCOL", "");
+		if (!StringUtils.isBlank(serverProtocolProperty)) {
+			return serverProtocolProperty.equalsIgnoreCase("https") ? 1: 0;
+		}
+
 		if (request != null && request.getScheme() != null)
 			return request.getScheme().equalsIgnoreCase("http") ? 0 : 1;
 


### PR DESCRIPTION
Issue: 84161

Cuando una App está detrás de un Proxy Reverso, los HttpHeaders que le llegan al WebServer son incorrectos y no corresponden a donde realmente está siendo accedida.
Por lo tanto, el &HttpRequest, PathToUrl, etc, dan información inconsistente.

Para esto, existe los X-Forwarded-Headers que pueden ser enviados por el ProxyReverso.
Sin embargo, en Mizuho, no pueden tocar el Proxy Reverso, entonces se habilita una forma de modificar esto por configuración en el Archivo:

=> Se agrega posibilidad de Modificar:

- SERVER_NAME (ya existía)
- SERVER_PORT (nuevo)
- SERVER_PROTOCOL (nuevo)

client.cfg.prod:
```
[Client]
SERVER_NAME=myhost
SERVER_PORT=9191
SERVER_PROTOCOL=https
```

**Porque un archivo nuevo: client.cfg.prod?**
Porque el client.cfg no puede ser tocado a mano, ya que el Deploy lo sobreescribe. Entonces se crea una nueva opción para poder hacer override de propiedades del client.cfg. 