### PR TITLE
IBM Storage Copy Operation must be public as S3 Storage

### DIFF
--- a/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderIBM.java
+++ b/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderIBM.java
@@ -205,7 +205,7 @@ public class ExternalProviderIBM implements ExternalProvider {
 
         CopyObjectRequest request = new CopyObjectRequest(bucket, objectUrl, bucket, resourceKey);
         request.setNewObjectMetadata(metadata);
-        request.setCannedAccessControlList(getUploadACL(isPrivate));
+        request.setCannedAccessControlList(getUploadACL(false));
         client.copyObject(request);
         return ((AmazonS3Client) client).getResourceUrl(bucket, resourceKey);
     }


### PR DESCRIPTION
Until we don't merge Full Support for Public and Private Operation for Storage (pending Test by GXProduct), IBM Object Storage should never copy as Private. We cannot change the Generator code, because we would break Azure Storage. 


(We do not need this commit in BETA, as is already resolved by support for Private and Public Storage)