### PR TITLE
Do not PAD with white spaces when Character Attribute is NULL

### DIFF
--- a/java/src/main/java/com/genexus/db/driver/GXResultSet.java
+++ b/java/src/main/java/com/genexus/db/driver/GXResultSet.java
@@ -290,7 +290,7 @@ public final class GXResultSet implements ResultSet, com.genexus.db.IFieldGetter
 		{
 			value = result.getString(columnIndex);
 			if (result.wasNull() || value == null)
-				value = CommonUtil.replicate(" ", length);
+				value = "";
 			else
 				value = String.format(String.format("%%-%ds", length), value);
 		}


### PR DESCRIPTION
```
new
	DataItemId = &DataItemId
	DataItemCharacter.SetNull()
	DataItemVarChar.SetNull()
	DataItemLongVarchar.SetNull()
endnew
do 'Print'


&DataItemId = 2
new
	DataItemId = &DataItemId
	DataItemCharacter.SetEmpty()
	DataItemVarChar.SetEmpty()
	DataItemLongVarchar.SetEmpty()
endnew

```
**Expected Result**

```
TestCase : 1
&DataItemCharacter: ''
&DataItemVarChar: ''
&DataItemLongVarchar: ''
----------------------------------------------------------------------------
TestCase : 2
&DataItemCharacter: '                    '
&DataItemVarChar: ''
&DataItemLongVarchar: ''
```

**Actual Result:**

```
TestCase : 1
&DataItemCharacter:  '                    '
&DataItemVarChar: ''
&DataItemLongVarchar: ''
----------------------------------------------------------------------------
TestCase : 2
&DataItemCharacter: '                    '
&DataItemVarChar: ''
&DataItemLongVarchar: ''
```