### PR TITLE
Fix creation of entities from offline (parentinfo)

### DIFF
--- a/android/src/main/java/com/artech/base/services/IContext.java
+++ b/android/src/main/java/com/artech/base/services/IContext.java
@@ -26,9 +26,11 @@ public interface IContext {
 	IPropertiesObject getEmptyPropertiesObject();
 
 	IEntity createEntity(String module, String name, IEntity parent);
+	IEntity createEntity(String module, String name, IEntity parent, IEntityList collection);
+	IEntityList createEntityList();
 	
-        IPropertiesObject createPropertyObject();
-        IPropertiesObject runGxObjectFromProcedure(String objectToCall, IPropertiesObject parameters);
+    IPropertiesObject createPropertyObject();
+    IPropertiesObject runGxObjectFromProcedure(String objectToCall, IPropertiesObject parameters);
 
 	IAndroidSession getAndroidSession();
 	

--- a/android/src/main/java/com/artech/base/services/IEntityList.java
+++ b/android/src/main/java/com/artech/base/services/IEntityList.java
@@ -3,6 +3,5 @@ package com.artech.base.services;
 
 public interface IEntityList
 {
-
-
+	void add(IEntity entity);
 }


### PR DESCRIPTION
### Problema
Se estaban cargando mal las colecciones de entities, se necesita que sean EntityList la coleccion y que se asigne el parent info.

_ Evento GridBasadoEnSDT.Refresh en SD no se está tomando en cuenta
Issue [#74052](https://issues.genexus.com/viewissue.aspx?74052)

### Solucion
Se crean metodos en interfaces que implementan en el Flexible Client de Android que es donde se tiene acceso a las clases que se deben usar.