### PR TITLE
Cookie value was dirty if it was read from an InMemory Cookie Cache

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -861,13 +861,17 @@ public class HttpContextWeb extends HttpContext {
 	}
 
 	public String getCookie(String name) {
+		Cookie cookie = cookies.get(name);
+		if (cookie != null) {
+			return WebUtils.decodeCookie(cookie.getValue());
+		}
+
 		if (request != null) {
 			try {
 				Cookie[] cookies = request.getCookies();
-
 				if (cookies != null) {
 					for (int i = 0; i < cookies.length; i++) {
-						Cookie cookie = cookies[i];
+						cookie = cookies[i];
 						if (cookie.getName().equalsIgnoreCase(name)) {
 							return WebUtils.decodeCookie(cookie.getValue());
 						}
@@ -878,10 +882,6 @@ public class HttpContextWeb extends HttpContext {
 			}
 		}
 
-		Cookie cookie = cookies.get(name);
-		if (cookie != null) {
-			return WebUtils.decodeCookie(cookie.getValue());
-		}
 		return "";
 	}
 
@@ -916,7 +916,8 @@ public class HttpContextWeb extends HttpContext {
 			if (servletContext.getMajorVersion() >= 3)
 				cookie.setHttpOnly(httpOnly); // Requiere servlet version 3.0
 			response.addCookie(cookie);
-			cookies.put(name, cookie);
+
+			cookies.put(name, (Cookie)cookie.clone());
 		}
 
 		return 0;

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -64,7 +64,7 @@ public class HttpContextWeb extends HttpContext {
 	private String requestMethod;
 	protected String contentType = "";
 	private boolean SkipPushUrl = false;
-	private Hashtable<String, Cookie> cookies;
+	private Hashtable<String, String> cookies;
 	private boolean streamSet = false;
 	private WebSession webSession;
 	private FileItemCollection fileItemCollection;
@@ -229,7 +229,7 @@ public class HttpContextWeb extends HttpContext {
 
 		GX_msglist = new MsgList();
 		postData = null;
-		cookies = new Hashtable<>();
+		cookies = new Hashtable<String, String>();
 
 		httpRes = new HttpResponse(this);
 		httpReq = new HttpRequestWeb(this);
@@ -861,9 +861,8 @@ public class HttpContextWeb extends HttpContext {
 	}
 
 	public String getCookie(String name) {
-		Cookie cookie = cookies.get(name);
-		if (cookie != null) {
-			return WebUtils.decodeCookie(cookie.getValue());
+		if (cookies.containsKey(name)) {
+			return WebUtils.decodeCookie(cookies.get(name));
 		}
 
 		if (request != null) {
@@ -871,7 +870,7 @@ public class HttpContextWeb extends HttpContext {
 				Cookie[] cookies = request.getCookies();
 				if (cookies != null) {
 					for (int i = 0; i < cookies.length; i++) {
-						cookie = cookies[i];
+						Cookie cookie = cookies[i];
 						if (cookie.getName().equalsIgnoreCase(name)) {
 							return WebUtils.decodeCookie(cookie.getValue());
 						}
@@ -917,7 +916,7 @@ public class HttpContextWeb extends HttpContext {
 				cookie.setHttpOnly(httpOnly); // Requiere servlet version 3.0
 			response.addCookie(cookie);
 
-			cookies.put(name, (Cookie)cookie.clone());
+			cookies.put(name, value);
 		}
 
 		return 0;

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -861,27 +861,27 @@ public class HttpContextWeb extends HttpContext {
 	}
 
 	public String getCookie(String name) {
-		Object o = cookies.get(name);
-		if (o != null) {
-			return WebUtils.decodeCookie(((Cookie) o).getValue());
-		}
-
 		if (request != null) {
 			try {
 				Cookie[] cookies = request.getCookies();
 
 				if (cookies != null) {
 					for (int i = 0; i < cookies.length; i++) {
-						if (cookies[i].getName().equalsIgnoreCase(name)) {
-							return WebUtils.decodeCookie(cookies[i].getValue());
+						Cookie cookie = cookies[i];
+						if (cookie.getName().equalsIgnoreCase(name)) {
+							return WebUtils.decodeCookie(cookie.getValue());
 						}
 					}
 				}
 			} catch (Exception e) {
-				return "";
+				log.error("Failed getting cookie", e);
 			}
 		}
 
+		Cookie cookie = cookies.get(name);
+		if (cookie != null) {
+			return WebUtils.decodeCookie(cookie.getValue());
+		}
 		return "";
 	}
 

--- a/push.bat
+++ b/push.bat
@@ -1,6 +1,0 @@
-
-SET lib=C:\Program Files\Apache Software Foundation\Tomcat 8.5\webapps\TestStoreJavaSqlIBM\WEB-INF\lib
-echo %lib%
-copy "java\target\gxclassR.jar" "%lib%\gxclassR.jar" /Y
-copy "common\target\gxcommon.jar" "%lib%\gxcommon.jar" /Y
-copy "gxexternalpobject_idroviders\target\gxexternalproviders.jar" "%lib%\gxexternalproviders.jar" /Y

--- a/push.bat
+++ b/push.bat
@@ -1,0 +1,6 @@
+
+SET lib=C:\Program Files\Apache Software Foundation\Tomcat 8.5\webapps\TestStoreJavaSqlIBM\WEB-INF\lib
+echo %lib%
+copy "java\target\gxclassR.jar" "%lib%\gxclassR.jar" /Y
+copy "common\target\gxcommon.jar" "%lib%\gxcommon.jar" /Y
+copy "gxexternalpobject_idroviders\target\gxexternalproviders.jar" "%lib%\gxexternalproviders.jar" /Y


### PR DESCRIPTION
In some cases using IBM WAS, the WebServer container was altering the Cookie Value (adding HTTPOnly attibute).
Thus, if we read again the Cookie value in the same request, it got corrupted***.
We need to clone the Cookie in order to read the original value. 

***This error was produced due to a JDK bug, that was fixed in JDK9. 

Issue: 85144

Before FIX (setCookie and GetCookie will output):

```
{
	"id": "test",
	"value": "test1ValueofCookie; **HTTPOnly**"
}
```

After FIX (setCookie and GetCookie will output):

```
{
	"id": "test",
	"value": "test1ValueofCookie"
}
```