### PR TITLE
HttpContext was null for some circunstances, so JWT Encryption Key was corruputed

### DIFF
--- a/java/src/main/java/com/genexus/security/web/WebSecurityHelper.java
+++ b/java/src/main/java/com/genexus/security/web/WebSecurityHelper.java
@@ -21,28 +21,16 @@ public class WebSecurityHelper {
         return StringUtils.strip(output);
      }
 	
-	 public static String sign(String pgmName, String issuer, String value, SecurityMode mode)
+	 public static String sign(String pgmName, String issuer, String value, SecurityMode mode, String key)
      {            
 		 WebSecureToken token = new WebSecureToken(pgmName, issuer, StripInvalidChars(value));
-         return SecureTokenHelper.sign(token, mode, getSecretKey());
+         return SecureTokenHelper.sign(token, mode, key);
      }
 
-     private static String getSecretKey()
-     {    	 
-		String hashSalt = com.genexus.Application.getClientContext().getClientPreferences().getREORG_TIME_STAMP(); //Some random SALT that is different in every GX App installation. Better if changes over time
-		return WebUtils.getEncryptionKey(ModelContext.getModelContext(), "") + hashSalt;
-     }
-/*
-     public static boolean verify(String pgmName, String issuer, String value, String jwtToken)
-     {
-         WebSecureToken token = new WebSecureToken();
-         return WebSecurityHelper.verify(pgmName, issuer, value, jwtToken, token);
-     }
-  */
-     public static boolean verify(String pgmName, String issuer, String value, String jwtToken)
+     public static boolean verify(String pgmName, String issuer, String value, String jwtToken, String key)
      {
     	 WebSecureToken token = new WebSecureToken();
-    	 if(!SecureTokenHelper.verify(jwtToken, token, getSecretKey()))
+    	 if(!SecureTokenHelper.verify(jwtToken, token, key))
     		 return false;            
     	 boolean ret = !StringUtils.isBlank(pgmName) && token.get_pgmName().equals(pgmName) && issuer.equals(token.get_issuer()) &&
     			 StripInvalidChars(value).equals(StripInvalidChars(token.get_value())) && new Date().compareTo(token.get_expiration()) < 0;

--- a/java/src/main/java/com/genexus/webpanels/GXWebObjectBase.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebObjectBase.java
@@ -479,8 +479,15 @@ public abstract class GXWebObjectBase implements IErrorHandler, GXInternetConsta
 
 	private String getObjectAccessWebToken(String cmpCtx)
 	{
-		return WebSecurityHelper.sign(getPgmInstanceId(cmpCtx), "", "", SecureTokenHelper.SecurityMode.Sign);
+		return WebSecurityHelper.sign(getPgmInstanceId(cmpCtx), "", "", SecureTokenHelper.SecurityMode.Sign, getSecretKey());
 	}
+
+	private String getSecretKey()
+    {
+    	//Some random SALT that is different in every GX App installation. Better if changes over time
+       String hashSalt = com.genexus.Application.getClientContext().getClientPreferences().getREORG_TIME_STAMP();
+       return WebUtils.getEncryptionKey(this.context, "") + hashSalt;
+    }
 
 	private String serialize(double Value, String Pic)
     {
@@ -615,7 +622,7 @@ public abstract class GXWebObjectBase implements IErrorHandler, GXInternetConsta
 
     protected String getSecureSignedToken(String cmpCtx, String Value)
     {
-    	return WebSecurityHelper.sign(getPgmInstanceId(cmpCtx), "", Value, SecureTokenHelper.SecurityMode.Sign);
+    	return WebSecurityHelper.sign(getPgmInstanceId(cmpCtx), "", Value, SecureTokenHelper.SecurityMode.Sign, getSecretKey());
     }
 
     protected boolean verifySecureSignedToken(String cmpCtx, int Value, String picture, String token){
@@ -651,7 +658,7 @@ public abstract class GXWebObjectBase implements IErrorHandler, GXInternetConsta
     }
 
     protected boolean verifySecureSignedToken(String cmpCtx, String value, String token){
-    	return WebSecurityHelper.verify(getPgmInstanceId(cmpCtx), "", value, token);
+    	return WebSecurityHelper.verify(getPgmInstanceId(cmpCtx), "", value, token, getSecretKey());
     }
 
 	protected boolean validateObjectAccess(String cmpCtx)


### PR DESCRIPTION
Issue: 85413

The problem was that the getEncyptionKey was being obtained from the Current Static Model Context. Changed to http current context.


**Full Stack Error:**

```
2020-09-23T16:03:14.917-03:00 [http-nio-8080-exec-290] DEBUG com.genexus.security.web.SecureTokenHelper - Web Token Encryption Exception for Token 
TOKEN: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJneC1leHAiOiIxNjAyMTgzNzc1NDA3IiwiZ3gtcGdtIjoiV0VCUEFORUwxIn0.5O4L5TDPslJ5G8J-kmaInlZ7ig9igbRnwRlXzhMcXeo'
java.security.SignatureException: signature verification failed
	at com.genexus.security.web.jose.jwt.JWTVerifier.verifyHmac(JWTVerifier.java:153) ~[gxclassR.jar:?]
	at com.genexus.security.web.jose.jwt.JWTVerifier.verifySignature(JWTVerifier.java:133) ~[gxclassR.jar:?]
	at com.genexus.security.web.jose.jwt.JWTVerifier.verify(JWTVerifier.java:117) ~[gxclassR.jar:?]
	at com.genexus.security.web.SecureTokenHelper.verify(SecureTokenHelper.java:63) [gxclassR.jar:?]
	at com.genexus.security.web.WebSecurityHelper.verify(WebSecurityHelper.java:45) [gxclassR.jar:?]
	at com.genexus.webpanels.GXWebObjectBase.verifySecureSignedToken(GXWebObjectBase.java:654) [gxclassR.jar:?]
	at com.genexus.webpanels.GXWebObjectBase.validateObjectAccess(GXWebObjectBase.java:665) [gxclassR.jar:?]
	at com.genexus.webpanels.GXWebPanel$DynAjaxEvent.invoke(GXWebPanel.java:1116) [gxclassR.jar:?]
	at com.genexus.webpanels.GXWebPanel.webAjaxEvent(GXWebPanel.java:469) [gxclassR.jar:?]
	at com.genexus.webpanels.GXWebPanel.webExecuteEx(GXWebPanel.java:420) [gxclassR.jar:?]
	at com.genexus.webpanels.GXWebPanel.doExecute(GXWebPanel.java:443) [gxclassR.jar:?]
	at com.it369227.webpanel1.doExecute(webpanel1.java:14) [classes/:?]
```