### PR TITLE
Do not throw Exception when Deleting Post Value Prefix 

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpAjaxContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpAjaxContext.java
@@ -495,7 +495,12 @@ public abstract class HttpAjaxContext
                 com.genexus.internet.HttpContext webContext = (HttpContext) com.genexus.ModelContext.getModelContext().getHttpContext();
 				if (justCreated)
 				{
-					webContext.DeletePostValuePrefix(cmpCtx);
+					try {
+						webContext.DeletePostValuePrefix(cmpCtx);
+					}
+					catch (Exception e) {
+						logger.error("Could not delete post value prefix", e);
+					}
 				}
                 ComponentObjects.put(cmpCtx, objName);
             }


### PR DESCRIPTION
This commit was merged and closed on BETA by January 2020, but never merged to Master. 

Full Exception:

```
javax.servlet.ServletException: java.lang.NullPointerException
	at org.apache.coyote.http11.Http11InputBuffer.fill(Http11InputBuffer.java:717)
	at org.apache.coyote.http11.Http11InputBuffer.access$300(Http11InputBuffer.java:40)
	at org.apache.coyote.http11.Http11InputBuffer$SocketInputBuffer.doRead(Http11InputBuffer.java:1072)
	at org.apache.coyote.http11.Http11InputBuffer.doRead(Http11InputBuffer.java:259)
	at org.apache.coyote.Request.doRead(Request.java:581)
	at org.apache.catalina.connector.InputBuffer.realReadBytes(InputBuffer.java:326)
	at org.apache.catalina.connector.InputBuffer.checkByteBufferEof(InputBuffer.java:642)
	at org.apache.catalina.connector.InputBuffer.read(InputBuffer.java:349)
	at org.apache.catalina.connector.CoyoteInputStream.read(CoyoteInputStream.java:183)
	at java.base/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.base/java.io.InputStreamReader.read(InputStreamReader.java:185)
	at java.base/java.io.Reader.read(Reader.java:140)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1680)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1659)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:1636)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:1611)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:668)
	at com.genexus.webpanels.HttpUtils.parsePostData(HttpUtils.java:114)
	at com.genexus.webpanels.HttpContextWeb.parsePostData(HttpContextWeb.java:1217)
	at com.genexus.webpanels.HttpContextWeb.getPostData(HttpContextWeb.java:377)
	at com.genexus.webpanels.HttpContextWeb.DeletePostValuePrefix(HttpContextWeb.java:1176)
	at com.genexus.internet.HttpAjaxContext.AddComponentObject(HttpAjaxContext.java:498)
	at com.issue85413.rwdrecentlinks_impl.componentprepare(rwdrecentlinks_impl.java:1046)
	at com.issue85413.rwdmasterpage_impl.e12042(rwdmasterpage_impl.java:587)
	at com.issue85413.rwdmasterpage_impl.rf042(rwdmasterpage_impl.java:499)
	at com.issue85413.rwdmasterpage_impl.refresh(rwdmasterpage_impl.java:478)
	at com.issue85413.rwdmasterpage_impl.we042(rwdmasterpage_impl.java:416)
	at com.issue85413.rwdmasterpage_impl.webExecute(rwdmasterpage_impl.java:50)
	at com.issue85413.transaction1_impl.webExecute(transaction1_impl.java:158)
	at com.genexus.webpanels.GXWebPanel.webExecuteEx(GXWebPanel.java:428)
	at com.genexus.webpanels.GXWebPanel.doExecute(GXWebPanel.java:443)
	at com.issue85413.transaction1.doExecute(transaction1.java:14)
	at com.genexus.webpanels.GXWebObjectStub.callDoExecute(GXWebObjectStub.java:242)
	at com.genexus.webpanels.GXWebObjectStub.callExecute(GXWebObjectStub.java:124)
	at com.genexus.webpanels.GXWebObjectStub.doGet(GXWebObjectStub.java:45)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:635)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
```