### PR TITLE
Clean ModelContext after an HTTP Object Upload

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/GXObjectUploadServices.java
+++ b/java/src/main/java/com/genexus/webpanels/GXObjectUploadServices.java
@@ -106,28 +106,30 @@ public class GXObjectUploadServices extends GXWebObjectStub
 				jObj.put("object_id", CommonUtil.UPLOADPREFIX + keyId);
 				context.writeText(jObj.toString());
 				context.getResponse().flushBuffer();
-				return;
 			}
 		}
 		catch (Throwable e)
 		{
 			context.sendResponseStatus(404, e.getMessage());
 		}
+		finally {
+			ModelContext.deleteThreadContext();
+		}
     }
 	
 	protected boolean IntegratedSecurityEnabled( )
 	{
-	return com.genexus.Application.getClientPreferences().getProperty("EnableIntegratedSecurity", "0").equals("1");
+		return com.genexus.Application.getClientPreferences().getProperty("EnableIntegratedSecurity", "0").equals("1");
 	}
 
 	protected int IntegratedSecurityLevel( )
 	{
-	return SECURITY_GXOBJECT;
+		return SECURITY_GXOBJECT;
 	}
 
 	protected String IntegratedSecurityPermissionPrefix( )
 	{
-	return "";
+		return "";
 	}   
 
 	private String getExtension(String contentType)


### PR DESCRIPTION
Issue: 85633

Every Http Upload via 'gxObject' endpoint, would leak the ModelContext static ThreadLocal variable.
In that case, if the Tomcat Thread was reused by the Pool for other Request, the ModelContext would point to an invalid old reference. 


Best case scenario, an exception was thrown. But maybe in other cases, it would behave incorrectly. 

```
Caused by: java.lang.NullPointerException
at org.apache.catalina.connector.Response.generateCookieString(Response.java:981) ~[catalina.jar:8.5.47]
at org.apache.catalina.connector.Response.addCookie(Response.java:929) ~[catalina.jar:8.5.47]
at org.apache.catalina.connector.ResponseFacade.addCookie(ResponseFacade.java:386) ~[catalina.jar:8.5.47]
at javax.servlet.http.HttpServletResponseWrapper.addCookie(HttpServletResponseWrapper.java:58) ~[servlet-api.jar:?]
at com.genexus.webpanels.HttpContextWeb.setCookieRaw(HttpContextWeb.java:867) ~[gxclassR.jar:?]
at com.genexus.webpanels.HttpContextWeb.setCookieRaw(HttpContextWeb.java:841) ~[gxclassR.jar:?]
at com.genexus.webpanels.HttpContextWeb.setCookie(HttpContextWeb.java:880) ~[gxclassR.jar:?]
at com.genexus.internet.HttpContext.initClientId(HttpContext.java:880) ~[gxclassR.jar:?]
at com.genexus.GXProcedure.<init>(GXProcedure.java:111) ~[gxclassR.jar:?]
at com.genexus.GXProcedure.<init>(GXProcedure.java:36) ~[gxclassR.jar:?]
```
