### PR TITLE
Internet Explorer not being detected when using BrowserId() function

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -684,12 +684,12 @@ public class HttpContextWeb extends HttpContext {
 					return BROWSER_IE;
 			} else if (userAgent.toUpperCase().indexOf("SAFARI") != -1) {
 				return BROWSER_SAFARI;
-			} else if (userAgent.toUpperCase().indexOf("MOZILLA/") != -1) {
-				return BROWSER_NETSCAPE;
 			} else if ((userAgent.indexOf("Trident")) != -1) {
 				return BROWSER_IE;
 			} else if (userAgent.toUpperCase().indexOf("OPERA") != -1) {
 				return BROWSER_OPERA;
+			} else if (userAgent.toUpperCase().indexOf("MOZILLA/") != -1) {
+				return BROWSER_NETSCAPE;
 			} else if (userAgent.toUpperCase().indexOf("UP.Browser") != -1) {
 				return BROWSER_UP;
 			} else if (USERAGENT_SEARCH_BOT.matcher(userAgent).find()) {


### PR DESCRIPTION
```
Event Start
	&BrowserId = BrowserID()

	msg(!"&BrowserId: " + &BrowserId.ToString().Trim())
Endevent
```

Output (when Using Internet Explorer 11):
`2`

Expected Result:
`1`

Issue: 86218

https://wiki.genexus.com/commwiki/servlet/wiki?8336,BrowserId+function