### PR TITLE
Fix duplicate cache invalidation token

### DIFF
--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -2597,6 +2597,11 @@ public final class CommonUtil
 		return url.startsWith("http://") || url.startsWith("https://") || url.startsWith("ftp://") || url.startsWith("sd:");
 	}
 
+	public static boolean hasUrlQueryString(String url)
+	{
+		return url.indexOf("?") >= 0;
+	}
+
 	public static String encodeJSON(String in)
 	{
 		String encoded = JSONObject.quote(in).replaceAll("'", "\\\\u0027");

--- a/java/src/main/java/com/genexus/GXutil.java
+++ b/java/src/main/java/com/genexus/GXutil.java
@@ -1637,6 +1637,11 @@ public final class GXutil
 		return CommonUtil.isAbsoluteURL(url);
 	}
 
+	public static boolean hasUrlQueryString(String url)
+	{
+		return CommonUtil.hasUrlQueryString(url);
+	}
+
 	public static void ErrorToMessages(String errorId, String errorDescription, GXBaseCollection<SdtMessages_Message> messages)
 	{
 		if (messages != null)

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -497,15 +497,16 @@ public abstract class HttpContext
 	{
 		AddStyleSheetFile(styleSheet, "");
 	}
+
 	public void AddStyleSheetFile(String styleSheet, String urlBuildNumber)
 	{
 		urlBuildNumber = getURLBuildNumber(styleSheet, urlBuildNumber);
 		AddStyleSheetFile(styleSheet, urlBuildNumber, false);
 	}
 
-	private String getURLBuildNumber(String styleSheet, String urlBuildNumber)
+	private String getURLBuildNumber(String resourcePath, String urlBuildNumber)
 	{
-		if(urlBuildNumber.isEmpty() && !GXutil.isAbsoluteURL(styleSheet))
+		if(urlBuildNumber.isEmpty() && !GXutil.isAbsoluteURL(resourcePath) && !GXutil.hasUrlQueryString(resourcePath))
 		{
 			return "?" + getCacheInvalidationToken();
 		}


### PR DESCRIPTION
The cache invalidation token was being added twice to deferred JavaScript files #260. This came up in DotNet after https://github.com/genexuslabs/DotNetClasses/pull/260 and the same happened in Java.

Related PR in DotNet: https://github.com/genexuslabs/DotNetClasses/pull/262

#### Changes proposed in this Pull Request

- Verify that the resource URI doesn't already have a query string, before adding the cache invalidation token.

Issue:84288