### PR TITLE
Remove duplicate dependency definition for "gxclassr.jar".

### DIFF
--- a/gxandroidpublisher/pom.xml
+++ b/gxandroidpublisher/pom.xml
@@ -33,12 +33,6 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>gxclassR</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
#Fix build warning: "Some problems were encountered while building the effective model for com.genexus:gxandroidpublisher:jar:101.9-SNAPSHOT
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: ${project.groupId}:gxclassR:jar -> duplicate declaration of version ${project.version} @ line 37, column 21"