### PR TITLE
Do not send GX_CLIENT_ID Cookie for SOAP Requests

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -873,7 +873,7 @@ public abstract class HttpContext
 	
 	public void initClientId()
 	{			
-		if (getWebSession() != null && this.getClientId().equals(""))
+		if (!isSoapRequest() && getWebSession() != null && this.getClientId().equals(""))
 		{                    
 			String _clientId = this.getCookie(CLIENT_ID_HEADER);
 			if (_clientId == null || _clientId.equals(""))


### PR DESCRIPTION
Do not send:

`Set-Cookie	GX_CLIENT_ID=4deca8cf-ca2a-4baa-b934-5cb27dc10c5a; HTTPOnly; Expires=Tue, 12-Mar-58 06:06:47 GMT; HttpOnly`

As this Cookie is not needed for SOAP Requests and was forcedly creating a new WebSession for every SOAP Request. 
 
This Cookie/Header is used for SDApps:  ClientInformation.Id

Issue: 86173