### PR TITLE
Fixed GxDrawBitMap to consider https protocol urls

### DIFF
--- a/java/src/main/java/com/genexus/reports/PDFReportItext.java
+++ b/java/src/main/java/com/genexus/reports/PDFReportItext.java
@@ -878,7 +878,7 @@ public class PDFReportItext implements IReportHandler
 						bitmap = bitmap.replace(httpContext.getStaticContentBase(), "");
 					}				
 				
-					if(!new File(bitmap).isAbsolute() && !bitmap.toLowerCase().startsWith("http"))
+					if (!new File(bitmap).isAbsolute() && !bitmap.toLowerCase().startsWith("http:") && !bitmap.toLowerCase().startsWith("https:"))
 					{ 
 						if (bitmap.startsWith(httpContext.getStaticContentBase()))
 						{


### PR DESCRIPTION
[Issue:87177](https://issues.genexus.com/viewissue.aspx?IssueId=87177)

Fixed PDFReportItext.GxDrawBitMap to consider https protocol when checking if the bitmap path is a url.