### PR TITLE
Remove semicolon that's causing cast exceptions when generating PDFs

### DIFF
--- a/java/src/main/java/com/genexus/reports/PDFReportItext.java
+++ b/java/src/main/java/com/genexus/reports/PDFReportItext.java
@@ -1314,7 +1314,7 @@ public class PDFReportItext implements IReportHandler
 								bottomAux = bottomAux - drawingPageHeight;
 							}
 						}
-						if (objects.get(k) instanceof Paragraph);
+						if (objects.get(k) instanceof Paragraph)
 							((Paragraph)objects.get(k)).setAlignment(columnAlignment(alignment));
 
 						Col.addElement((Element)objects.get(k));


### PR DESCRIPTION
[Issue:87115](https://issues.genexus.com/viewissue.aspx?IssueId=87115)

There was an extra semicolon at the end of an `if` statement that was forcing the intended code to be executed when the check succeeded, to always be executed.