### PR TITLE
Get Method of Cache API must not return nulls because GeneXus can´t h…

### DIFF
--- a/java/src/main/java/com/genexus/util/CacheAPI.java
+++ b/java/src/main/java/com/genexus/util/CacheAPI.java
@@ -55,7 +55,10 @@ public class CacheAPI
     
     public String get(String key)
     {   
-        return cache.get(cacheId, key, String.class);
+        String value = cache.get(cacheId, key, String.class);
+    	if (value == null)
+    		value = "";
+        return value;
     }
 
     public void remove(String key)


### PR DESCRIPTION
…andle it.

Issue: 87429