### PR TITLE
fix Send By Batches DP in Android

### DIFF
--- a/android/src/main/java/com/artech/base/synchronization/dps/getpendingeventandcheckpointsbytimestamp.java
+++ b/android/src/main/java/com/artech/base/synchronization/dps/getpendingeventandcheckpointsbytimestamp.java
@@ -207,7 +207,7 @@ final  class getpendingeventandcheckpointsbytimestamp__default extends DataStore
 {
    protected Object[] conditional_P00022( ModelContext context ,
                                           int remoteHandle ,
-                                          com.genexus.internet.HttpContext httpContext ,
+                                          com.genexus.IHttpContext httpContext ,
                                           short AV5PendingEventStatus ,
                                           short A6PendingEventStatus )
    {
@@ -249,7 +249,7 @@ final  class getpendingeventandcheckpointsbytimestamp__default extends DataStore
    public Object [] getDynamicStatement( int cursor ,
                                          ModelContext context ,
                                          int remoteHandle ,
-                                         com.genexus.internet.HttpContext httpContext ,
+                                         com.genexus.IHttpContext httpContext ,
                                          Object [] dynConstraints )
    {
       switch ( cursor )


### PR DESCRIPTION
Issue:

Se cierra la aplicación al intentar enviar eventos pendientes cuando se usa Synchronization.SetSendCheckpoint()
https://issues.genexus.com/viewissue.aspx?87699

Estaba mal el parametro de los context en los conditional y dynamic methods.
Se arreglo el tipo de los parametros.