### PR TITLE
XMLHttp Response with SPA Redirect Headers were being cached in Internet Explorer 11

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -1357,6 +1357,7 @@ public class HttpContextWeb extends HttpContext {
 			if (isSpaRequest(true)) {
 				pushUrlSessionStorage();
 				getResponse().setHeader(GX_SPA_REDIRECT_URL, url + popLvlParm);
+				sendCacheHeaders();
 			} else {
 				redirect_http(url + popLvlParm);
 			}


### PR DESCRIPTION
Issue: 87514

Prevent Cache header were missing in SPA Redirect Responses:

```
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT
```