### PR TITLE
Change mechanism to set JSESSION id cookie as secure

### DIFF
--- a/java/src/main/java/com/genexus/filters/SecureCookieHttpServletResponseWrapper.java
+++ b/java/src/main/java/com/genexus/filters/SecureCookieHttpServletResponseWrapper.java
@@ -1,0 +1,21 @@
+package com.genexus.filters;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+public class SecureCookieHttpServletResponseWrapper extends HttpServletResponseWrapper {
+
+	String cookieId;
+    public SecureCookieHttpServletResponseWrapper(HttpServletResponse response, String cookieId) {
+        super(response);
+		this.cookieId = cookieId.toLowerCase();
+    }
+	@Override
+	public void addCookie(Cookie cookie) {
+		if (!cookie.getSecure() && cookie.getName().toLowerCase()==cookieId){
+			cookie.setSecure(true);
+		}
+		super.addCookie(cookie);
+	}
+}

--- a/java/src/main/java/com/genexus/filters/SessionFilter.java
+++ b/java/src/main/java/com/genexus/filters/SessionFilter.java
@@ -1,0 +1,43 @@
+package com.genexus.filters;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import javax.servlet.*;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class SessionFilter implements Filter{
+	String JSESSIONID="JSESSIONID";
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        String sessionCookieName = filterConfig.getServletContext().getSessionCookieConfig().getName();
+        if (sessionCookieName!=null && !sessionCookieName.equals("")) {
+			JSESSIONID=sessionCookieName;
+		}
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+		Cookie session=null;
+        Cookie[] allCookies = req.getCookies();
+		if (allCookies != null) {
+			session = Arrays.stream(allCookies).filter(x -> x.getName().equals(JSESSIONID)).findFirst().orElse(null);
+		}
+		if (session!=null && req.isSecure() && !session.getSecure())
+		{
+			chain.doFilter(request, new SecureCookieHttpServletResponseWrapper(res, JSESSIONID));
+		}
+		else{
+			chain.doFilter(req, res);
+		}
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+}

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -1,5 +1,6 @@
 package com.genexus.webpanels;
 
+import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -238,12 +239,6 @@ public class HttpContextWeb extends HttpContext {
 		loadParameters(req.getQueryString());
 		isCrawlerRequest = isCrawlerRequest();
 
-		if (servletContext!=null) {
-			SessionCookieConfig scc = servletContext.getSessionCookieConfig();
-			if (scc!=null && req.isSecure() && !scc.isSecure()) {
-				scc.setSecure(true);
-			}
-		}
 	}
 
 	private void loadParameters(String value) {
@@ -1512,8 +1507,7 @@ public class HttpContextWeb extends HttpContext {
 	}
 
 	String sameSiteMode;
-	private void proxyCookieValues()
-	{
+	private void proxyCookieValues() {
 		if (sameSiteMode == null) {
 			String sameSiteModeValue = Application.getClientPreferences().getProperty("SAMESITE_COOKIE", "");
 			if (sameSiteModeValue.equals(SAME_SITE_NONE) || sameSiteModeValue.equals(SAME_SITE_LAX) || sameSiteModeValue.equals(SAME_SITE_STRICT))
@@ -1522,7 +1516,7 @@ public class HttpContextWeb extends HttpContext {
 				sameSiteMode = "";
 		}
 
-		if (!sameSiteMode.equals("")){
+		if (!sameSiteMode.equals("")) {
 			addSameSiteCookieAttribute(getResponse());
 		}
 	}


### PR DESCRIPTION
Issue:84715
Fix error:
HTTP Status 500 - java.lang.IllegalStateException: Property secure cannot be added to SessionCookieConfig for context /VirtualDir as the context has been initialized
