### PR TITLE
Remove mit-public Maven repo

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -34,6 +34,12 @@ jobs:
       with:
         java-version: 1.9
 
+    - name: Setup Maven settings
+      uses: whelk-io/maven-settings-xml-action@v14
+      with:
+        repositories: '[{ "id": "github-genexuslabs", "url": "https://maven.pkg.github.com/genexuslabs/Private-Maven-for-GX",  "releases": { "enabled": "true" }, "snapshots": { "enabled": "true" } }]'
+        servers: '[{ "id": "github-genexuslabs", "username": "genexusbot", "password": "${{ secrets.SECURE_TOKEN }}" }]'
+
     - name: Calculate build variables
       id: buildVariables
       run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,6 +53,12 @@ jobs:
       with:
         java-version: 1.9
 
+    - name: Setup Maven settings
+      uses: whelk-io/maven-settings-xml-action@v14
+      with:
+        repositories: '[{ "id": "github-genexuslabs", "url": "https://maven.pkg.github.com/genexuslabs/Private-Maven-for-GX", "releases": { "enabled": "true" }, "snapshots": { "enabled": "true" } }]'
+        servers: '[{ "id": "github-genexuslabs", "username": "genexusbot", "password": "${{ secrets.SECURE_TOKEN }}" }]'
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The dependencies between the projects are specified in each pom.xml within their
 - JDK 9 or greater
 - Maven 3.6 or greater
 
+In order to compile the *java* submodule, the [SAP JCo (SAP Java Connector)](https://support.sap.com/en/product/connectors/jco.html) needs to be installed in a Maven repository accessible while compiling (eg. the local Maven repository). This JAR can be downloaded from SAP's website (please note that a valid SAP Developer license may be required).
+
+In order to install the connector into the Maven local repository, open a terminal and execute:
+``` powershell
+mvn install:install-file -DgroupId=com.sap.conn.jco -DartifactId=sapjco3 -Dversion=3.0.14 -Dpackaging=jar -Dfile=sapjco3.jar
+```
+(The required version of the JCo jar can be found in [the POM file of the java submodule](https://github.com/genexuslabs/JavaClasses/blob/master/java/pom.xml))
+
 # Instructions
 
 ## How to build all projects?

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -151,6 +151,7 @@
 			<groupId>com.sap.conn.jco</groupId>
 			<artifactId>sapjco3</artifactId>
 			<version>3.0.14</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.ws.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,14 +37,6 @@
 		<module>androidreports</module>
     </modules>
 
-	<repositories>
-		<repository>
-			<id>mit-public</id>
-			<name>MIT Public</name>
-			<url>http://maven.mit.edu/nexus/content/repositories/public</url>
-		</repository>
-	</repositories>
-
 	<licenses>
 		<license>
 			<name>Apache 2.0</name>


### PR DESCRIPTION
The [mit-public](http://maven.mit.edu/nexus/content/repositories/public/) repository seems to have died and is causing our public builds to fail.

This PR:
- Removes the mit-public references in our POMs
- Configures the build environments with our internal Maven repository in GitHub
- Declares the SAP JCo dependency as optional (so that it's no longer included with GeneXus)

Issue:87866