### PR TITLE
Storage Provider not working for Web Transaction File Uploads

### DIFF
--- a/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
+++ b/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
@@ -1005,8 +1005,8 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 							if ( (dDelimIdx != -1) && (dDelimIdx < fileName.length() - 1) )
 							{
 								fileName = fileName.substring(dDelimIdx + 1);
-							}										
-							fileUri = Application.getExternalProvider().copy(sourceName, fileName, tableName, fieldName, true);
+							}
+							fileUri = Application.getExternalProvider().copy(gxFile.getAbsoluteName(), fileName, tableName, fieldName, true);
 						}
 						else
 						{


### PR DESCRIPTION
When copying the Attribute from the Private Temp Storage to the Final Destination, we were using the Token (gxupload:...) instead of the real Location. 

Issue:88648