### PR TITLE
Fix RegEx in Android, UNICODE_CHARACTER_CLASS flag not supported

### DIFF
--- a/android/src/main/java/com/genexus/specific/android/Connect.java
+++ b/android/src/main/java/com/genexus/specific/android/Connect.java
@@ -40,6 +40,7 @@ public final class Connect {
 		SpecificImplementation.SupportPending = true;
 		SpecificImplementation.cdowMask = "EEEE";
 		SpecificImplementation.Base64Encode = "8859_1";
+		SpecificImplementation.UseUnicodeCharacterClass = false;
 		JSONObject.extension = new JSONObjectExtension();
 		
 	}

--- a/common/src/main/java/com/genexus/GxRegex.java
+++ b/common/src/main/java/com/genexus/GxRegex.java
@@ -2,6 +2,8 @@ package com.genexus;
 
 import java.util.Vector;
 import java.util.regex.*;
+
+import com.genexus.common.interfaces.SpecificImplementation;
 import com.genexus.internet.*;
 
 public class  GxRegex
@@ -26,8 +28,13 @@ public class  GxRegex
 		{
 			if (txt.indexOf(CommonUtil.newLine()) > 0)
 				p = Pattern.compile(rex, Pattern.MULTILINE);
-			else
-				p = Pattern.compile(rex, Pattern.UNICODE_CHARACTER_CLASS);
+			else {
+				if (SpecificImplementation.UseUnicodeCharacterClass)
+					p = Pattern.compile(rex, Pattern.UNICODE_CHARACTER_CLASS);
+				else
+					p = Pattern.compile(rex);
+
+			}
 		}
 		catch(PatternSyntaxException e)
 		{

--- a/common/src/main/java/com/genexus/common/interfaces/SpecificImplementation.java
+++ b/common/src/main/java/com/genexus/common/interfaces/SpecificImplementation.java
@@ -33,4 +33,5 @@ public class SpecificImplementation {
 	public static String cdowMask;
 	public static boolean SendErrorOn401;
 	public static String Base64Encode = "GB2312";
+	public static boolean UseUnicodeCharacterClass;
 }

--- a/java/src/main/java/com/genexus/specific/java/Connect.java
+++ b/java/src/main/java/com/genexus/specific/java/Connect.java
@@ -44,6 +44,7 @@ public final class Connect {
 		SpecificImplementation.MillisecondMask = "S";
 		SpecificImplementation.cdowMask = "EEEEE";
 		SpecificImplementation.SupportPending = false;
+		SpecificImplementation.UseUnicodeCharacterClass = true;
 		JSONObject.extension = new JSONObjectExtension();
 		}
 		


### PR DESCRIPTION
### Problema

In RegEx, Pattern.UNICODE_CHARACTER_CLASS flag is not supported in Android.

RegEx no funciona en Android
Issue [#89649](https://issues.genexus.com/viewissue.aspx?89649)

### Solución

No poner el flag UNICODE_CHARACTER_CLASS  si se esta ejecutando en Android  . 

Los cambios viene de este PR:
https://github.com/genexuslabs/JavaClasses/pull/368

