### PR TITLE
#Fix: Google Storage Private Upload bad ACL options

### DIFF
--- a/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
+++ b/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
@@ -176,7 +176,7 @@ public class ExternalProviderGoogle implements ExternalProvider {
     }
 
     private List<ObjectAccessControl> getACLOptions(boolean isPrivate) {
-        if (isPrivate)
+        if (!isPrivate)
             return Arrays.asList(new ObjectAccessControl().setEntity("allUsers").setRole("READER"));
         else
             return new ArrayList<ObjectAccessControl>();


### PR DESCRIPTION
We should not add any ACL extra options for private uploads. This is because by default, all objects are private.

Issue 89895

