### PR TITLE
Fixed case sensitivity in headers in httpclient old implementation

### DIFF
--- a/common/src/main/java/com/genexus/internet/GXHttpClient.java
+++ b/common/src/main/java/com/genexus/internet/GXHttpClient.java
@@ -375,6 +375,12 @@ public abstract class GXHttpClient implements IHttpClient{
 		}
 		if (this.headersToSend == null)
 			this.headersToSend =new Hashtable<>();
+		for (String elem: headersToSend.keySet()) {
+			if (elem.equalsIgnoreCase(name)) {
+				headersToSend.put(elem, value);
+				return;
+			}
+		}
 		headersToSend.put(name, value);
 	}
 


### PR DESCRIPTION
Headers are not case-sentitive in HTTP protocol, and old httpclient implementation was allowing that. It's been fixed.