### PR TITLE
File.GetURI() error for Uploaded Files with File Upload Usercontrol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@ target/
 .settings
 *.versionsBackup
 
+*.xlsx
+
 PublicTempStorage/
 PrivateTempStorage/

--- a/java/src/main/java/com/genexus/util/GXFile.java
+++ b/java/src/main/java/com/genexus/util/GXFile.java
@@ -99,17 +99,15 @@ public class GXFile extends AbstractGXFile {
     }	
 
     public void setSource(String FileName) {
-    		setSource(FileName, !isExternal);
-    }
+		boolean isUpload = com.genexus.CommonUtil.isUploadPrefix(FileName);
+		if (isUpload) {
+			uploadFileId = FileName;
+			FileName = SpecificImplementation.GXutil.getUploadValue(FileName);
+		}
 
-    public void setSource(String FileName, boolean isLocal) {
-        if (Application.getGXServices().get(GXServices.STORAGE_SERVICE) != null && !isLocal) {
+        if (Application.getGXServices().get(GXServices.STORAGE_SERVICE) != null && (isUpload || isExternal)) {
         		FileSource = new GXExternalFileInfo(FileName, Application.getExternalProvider());
         } else {
-				if (com.genexus.CommonUtil.isUploadPrefix(FileName)) {
-					uploadFileId = FileName;
-					FileName = SpecificImplementation.GXutil.getUploadValue(FileName);
-				}
                 String absoluteFileName = FileName;
         		try {
         		    if (ModelContext.getModelContext() != null && ! new File(absoluteFileName).isAbsolute())


### PR DESCRIPTION
Couldn't get the File URI after a FileUpload was made, when External Storage was enabled. 

Example:
```
Event 'ProcessFiles'
	for &FileUploadData in &UploadedFiles
		&File = new()		
		&File.Source = &FileUploadData.File
		&FileUrl = &File.GetURI()
	endfor

EndEvent
```

Issue: 90094

Unit Test: KB TestStore (EnsureFileUploadGetUri)