### PR TITLE
Unhandled exception after blob update: GXRuntimeException: The filename does not exists in url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@ target/
 .settings
 *.versionsBackup
 
+*.xlsx
+
 PublicTempStorage/
 PrivateTempStorage/

--- a/common/src/main/java/com/genexus/db/driver/ExternalProviderCommon.java
+++ b/common/src/main/java/com/genexus/db/driver/ExternalProviderCommon.java
@@ -1,5 +1,7 @@
 package com.genexus.db.driver;
 
+import com.genexus.CommonUtil;
+
 public class ExternalProviderCommon {
 
 	public static String getProviderObjectName(ExternalProvider provider, String objectNameOrUrl)
@@ -14,6 +16,14 @@ public class ExternalProviderCommon {
 			}
 		}
 		return providerObjectName;
+	}
+
+	public static String getProviderObjectNameOrRelative(ExternalProvider provider, String objectNameOrUrl)
+	{
+		if (!CommonUtil.isAbsoluteURL(objectNameOrUrl)){
+			return objectNameOrUrl;
+		}
+		return  getProviderObjectName(provider, objectNameOrUrl);
 	}
 
 	public static String getProviderObjectAbsoluteUriSafe(ExternalProvider provider, String rawObjectUri)

--- a/java/src/main/java/com/genexus/util/GXFile.java
+++ b/java/src/main/java/com/genexus/util/GXFile.java
@@ -99,17 +99,15 @@ public class GXFile extends AbstractGXFile {
     }	
 
     public void setSource(String FileName) {
-    		setSource(FileName, !isExternal);
-    }
+		boolean isUpload = com.genexus.CommonUtil.isUploadPrefix(FileName);
+		if (isUpload) {
+			uploadFileId = FileName;
+			FileName = SpecificImplementation.GXutil.getUploadValue(FileName);
+		}
 
-    public void setSource(String FileName, boolean isLocal) {
-        if (Application.getGXServices().get(GXServices.STORAGE_SERVICE) != null && !isLocal) {
+        if (Application.getGXServices().get(GXServices.STORAGE_SERVICE) != null && (isUpload || isExternal)) {
         		FileSource = new GXExternalFileInfo(FileName, Application.getExternalProvider());
         } else {
-				if (com.genexus.CommonUtil.isUploadPrefix(FileName)) {
-					uploadFileId = FileName;
-					FileName = SpecificImplementation.GXutil.getUploadValue(FileName);
-				}
                 String absoluteFileName = FileName;
         		try {
         		    if (ModelContext.getModelContext() != null && ! new File(absoluteFileName).isAbsolute())

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -102,12 +102,13 @@ public class HttpContextWeb extends HttpContext {
 	}
 
 	public String getResourceRelative(String path, boolean includeBasePath) {
-		if (Application.getGXServices().get(GXServices.STORAGE_SERVICE) != null && !path.isEmpty()) {
+		if (Application.getExternalProvider() != null && !path.isEmpty()) {
+			if (CommonUtil.isAbsoluteURL(path))
+				return path;
 			GXFile gxFile = new GXFile(path);
 			String pathURL = gxFile.getAbsolutePath();
-			if (GXutil.isAbsoluteURL(pathURL)) {
+			if (CommonUtil.isAbsoluteURL(pathURL))
 				return pathURL;
-			}
 		}
 
 		try {


### PR DESCRIPTION
After updating an existing Transaction record, without modifying the blob value, an exception would be thrown:

`GXRuntimeException: The filename does not exists in url`

Issue: 90154

Added new UnitTest: 'EnsureImageUploadAndUpdate'