### PR TITLE
Google Storage crash after update existing blob

### DIFF
--- a/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
+++ b/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
@@ -244,7 +244,7 @@ public class ExternalProviderGoogle extends ExternalProviderBase implements Exte
 		CopyWriter copyWriter = blob.copyTo(this.bucket, newName);
 		Blob copiedBlob = copyWriter.getResult();
 		setBlobAcl(copiedBlob.getBlobId(), acl);
-		return getResourceUrl(copiedBlob, acl, defaultExpirationMinutes);
+		return url + StorageUtils.encodeName(newName);
 	}
 
 	public String copy(String objectUrl, String newName, String tableName, String fieldName, ResourceAccessControlList acl) {
@@ -258,7 +258,7 @@ public class ExternalProviderGoogle extends ExternalProviderBase implements Exte
 				CopyWriter copyWriter = blob.copyTo(bucket, resourceKey);
 				Blob copiedBlob = copyWriter.getResult();
 				setBlobAcl(copiedBlob.getBlobId(), acl);
-				return getResourceUrl(copiedBlob, acl, defaultExpirationMinutes);
+				return url + StorageUtils.encodeName(resourceKey);
 			} catch (Exception ex) {
 				logger.error("Error saving file to external provider", ex.getMessage());
 				return "";

--- a/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
+++ b/gxexternalproviders/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
@@ -206,7 +206,7 @@ public class ExternalProviderGoogle extends ExternalProviderBase implements Exte
 	private String getResourceUrl(BlobInfo blobInfo, ResourceAccessControlList acl, int expirationMinutes){
 		if (isPrivateResource(acl)){
 			expirationMinutes = expirationMinutes > 0 ? expirationMinutes: defaultExpirationMinutes;
-			return storageClient.signUrl(blobInfo, expirationMinutes, TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature()).toString();
+			return storageClient.signUrl(blobInfo, expirationMinutes, TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature(), Storage.SignUrlOption.withVirtualHostedStyle()).toString();
 		}
 		else {
 			return url + StorageUtils.encodeName(blobInfo.getName());
@@ -244,7 +244,7 @@ public class ExternalProviderGoogle extends ExternalProviderBase implements Exte
 		CopyWriter copyWriter = blob.copyTo(this.bucket, newName);
 		Blob copiedBlob = copyWriter.getResult();
 		setBlobAcl(copiedBlob.getBlobId(), acl);
-		return url + StorageUtils.encodeName(newName);
+		return getResourceUrl(copiedBlob, acl, defaultExpirationMinutes);
 	}
 
 	public String copy(String objectUrl, String newName, String tableName, String fieldName, ResourceAccessControlList acl) {
@@ -258,7 +258,7 @@ public class ExternalProviderGoogle extends ExternalProviderBase implements Exte
 				CopyWriter copyWriter = blob.copyTo(bucket, resourceKey);
 				Blob copiedBlob = copyWriter.getResult();
 				setBlobAcl(copiedBlob.getBlobId(), acl);
-				return url + StorageUtils.encodeName(resourceKey);
+				return getResourceUrl(copiedBlob, acl, defaultExpirationMinutes);
 			} catch (Exception ex) {
 				logger.error("Error saving file to external provider", ex.getMessage());
 				return "";


### PR DESCRIPTION
An exception would occur after updating a transaction record without modyfing the Blob Attribute.

Error exclusive to Google.

Issue: 90154

Test Case: EnsureImageUploadAndUpdate