### PR TITLE
Basic auth changed to raw auth header

### DIFF
--- a/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
+++ b/java/src/main/java/com/genexus/db/driver/GXPreparedStatement.java
@@ -35,6 +35,7 @@ import java.util.GregorianCalendar;
 
 import com.genexus.*;
 import com.genexus.common.classes.IGXPreparedStatement;
+import com.genexus.common.interfaces.SpecificImplementation;
 import com.genexus.internet.HttpContext;
 import com.genexus.util.GXFile;
 import com.genexus.util.GXServices;
@@ -954,6 +955,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 
 		fileName = fileName.trim();
 		blobPath = blobPath.trim();
+		String uploadNameValue = SpecificImplementation.GXutil.getUploadNameValue(blobPath);
 
 		//EMPTY BLOB
     	if (blobPath == null || blobPath.trim().length() == 0) {
@@ -971,7 +973,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 		{
 			blobPath = com.genexus.GXutil.cutUploadPrefix(blobPath);
 			File file = new File(blobPath);
-			fileUri = GXDbFile.generateUri(file.getName(), !GXDbFile.hasToken(blobPath), true);
+			fileUri = GXDbFile.generateUri(uploadNameValue.isEmpty()?file.getName(): uploadNameValue, !GXDbFile.hasToken(blobPath), true);
 		}
 
 		boolean externalStorageEnabled = storageProvider != null;
@@ -1016,7 +1018,7 @@ public class GXPreparedStatement extends GXStatement implements PreparedStatemen
 				GXFile gxFile = new GXFile(storageTargetObjectName, ResourceAccessControlList.Private); //Every temporal file is saved as private.
 				if (gxFile.exists()) {
 					// - 1. WebUpload: The URL is an External Storage URL in the Private Temp Storage Folder.
-					fileName = gxFile.getName();
+					fileName = uploadNameValue.isEmpty()? gxFile.getName(): uploadNameValue;
 					int idx = fileName.lastIndexOf("/");
 					if ((idx != -1) && (idx < fileName.length() - 1)) {
 						fileName = fileName.substring(idx + 1);

--- a/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
+++ b/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
@@ -250,6 +250,12 @@ public class HttpClientJavaLib extends GXHttpClient {
 		}
 	}
 
+	private void addBasicAuthHeader(String user, String password, Boolean isProxy) {
+		String auth = user + ":" + password;
+		String authHeader = "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.ISO_8859_1));
+		addHeader(isProxy ? HttpHeaders.PROXY_AUTHORIZATION: HttpHeaders.AUTHORIZATION, authHeader);
+	}
+
 	public void execute(String method, String url) {
 		resetExecParams();
 
@@ -291,9 +297,7 @@ public class HttpClientJavaLib extends GXHttpClient {
 
 				for (Enumeration en = getBasicAuthorization().elements(); en.hasMoreElements(); ) {	// No se puede hacer la autorizacion del tipo Basic con el BasicCredentialsProvider porque esta funcionando bien en todos los casos
 					HttpClientPrincipal p = (HttpClientPrincipal) en.nextElement();
-					String auth = p.user + ":" + p.password;
-					String authHeader = "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.ISO_8859_1));
-					addHeader(HttpHeaders.AUTHORIZATION, authHeader);
+					addBasicAuthHeader(p.user,p.password,false);
 				}
 
 				for (Enumeration en = getDigestAuthorization().elements(); en.hasMoreElements(); ) {
@@ -331,9 +335,7 @@ public class HttpClientJavaLib extends GXHttpClient {
 
 				for (Enumeration en = getBasicProxyAuthorization().elements(); en.hasMoreElements(); ) { // No se puede hacer la autorizacion del tipo Basic con el BasicCredentialsProvider porque esta funcionando bien en todos los casos
 					HttpClientPrincipal p = (HttpClientPrincipal) en.nextElement();
-					String auth = p.user + ":" + p.password;
-					String authHeader = "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.ISO_8859_1));
-					addHeader(HttpHeaders.PROXY_AUTHORIZATION, authHeader);
+					addBasicAuthHeader(p.user,p.password,true);
 				}
 
 				for (Enumeration en = getDigestProxyAuthorization().elements(); en.hasMoreElements(); ) {

--- a/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
+++ b/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
@@ -17,7 +17,6 @@ import com.genexus.CommonUtil;
 import com.genexus.specific.java.*;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.auth.AuthScope;
@@ -116,6 +115,8 @@ public class HttpClientJavaLib extends GXHttpClient {
 	private RequestConfig reqConfig = null;		// Atributo usado en la ejecucion del metodo (por ejemplo, httpGet, httpPost)
 	private CookieStore cookies;
 	private ByteArrayEntity entity = null;	// Para mantener el stream luego de cerrada la conexion en la lectura de la response
+	private Boolean lastAuthIsBasic = null;
+	private Boolean lastAuthProxyIsBasic = null;
 	private static IniFile clientCfg = new com.genexus.ModelContext(com.genexus.ModelContext.getModelContextPackageClass()).getPreferences().getIniFile();
 
 
@@ -138,6 +139,24 @@ public class HttpClientJavaLib extends GXHttpClient {
 				e.printStackTrace();
 			}
 		}
+	}
+
+	@Override
+	public void addAuthentication(int type, String realm, String name, String value) {	// Metodo overriden por tratarse de forma distinta el pasaje de auth Basic y el resto
+		if (type == BASIC)
+			lastAuthIsBasic = true;
+		else
+			lastAuthIsBasic = false;
+		super.addAuthentication(type,realm,name,value);
+	}
+
+	@Override
+	public void addProxyAuthentication(int type, String realm, String name, String value) {	// Metodo overriden por tratarse de forma distinta el pasaje de auth Basic y el resto
+		if (type == BASIC)
+			lastAuthProxyIsBasic = true;
+		else
+			lastAuthProxyIsBasic = false;
+		super.addProxyAuthentication(type,realm,name,value);
 	}
 
 	private void resetStateAdapted()
@@ -251,9 +270,12 @@ public class HttpClientJavaLib extends GXHttpClient {
 	}
 
 	private void addBasicAuthHeader(String user, String password, Boolean isProxy) {
-		String auth = user + ":" + password;
-		String authHeader = "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.ISO_8859_1));
-		addHeader(isProxy ? HttpHeaders.PROXY_AUTHORIZATION: HttpHeaders.AUTHORIZATION, authHeader);
+		Boolean typeAuth = isProxy ? this.lastAuthProxyIsBasic : this.lastAuthIsBasic;
+		if (typeAuth) {
+			String auth = user + ":" + password;
+			String authHeader = "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.ISO_8859_1));
+			addHeader(isProxy ? HttpHeaders.PROXY_AUTHORIZATION : HttpHeaders.AUTHORIZATION, authHeader);
+		}
 	}
 
 	public void execute(String method, String url) {

--- a/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
+++ b/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
@@ -3,6 +3,7 @@ package com.genexus.internet;
 import java.io.*;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -16,6 +17,7 @@ import com.genexus.CommonUtil;
 import com.genexus.specific.java.*;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.auth.AuthScope;
@@ -287,11 +289,11 @@ public class HttpClientJavaLib extends GXHttpClient {
 			if (getHostChanged() || getAuthorizationChanged()) { // Si el host cambio o si se agrego alguna credencial
 				this.credentialsProvider = new BasicCredentialsProvider();
 
-				for (Enumeration en = getBasicAuthorization().elements(); en.hasMoreElements(); ) {
+				for (Enumeration en = getBasicAuthorization().elements(); en.hasMoreElements(); ) {	// No se puede hacer la autorizacion del tipo Basic con el BasicCredentialsProvider porque esta funcionando bien en todos los casos
 					HttpClientPrincipal p = (HttpClientPrincipal) en.nextElement();
-					this.credentialsProvider.setCredentials(
-						AuthScope.ANY,
-						new UsernamePasswordCredentials(p.user, p.password));
+					String auth = p.user + ":" + p.password;
+					String authHeader = "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.ISO_8859_1));
+					addHeader(HttpHeaders.AUTHORIZATION, authHeader);
 				}
 
 				for (Enumeration en = getDigestAuthorization().elements(); en.hasMoreElements(); ) {
@@ -327,11 +329,11 @@ public class HttpClientJavaLib extends GXHttpClient {
 					this.credentialsProvider = new BasicCredentialsProvider();
 				}
 
-				for (Enumeration en = getBasicProxyAuthorization().elements(); en.hasMoreElements(); ) {
+				for (Enumeration en = getBasicProxyAuthorization().elements(); en.hasMoreElements(); ) { // No se puede hacer la autorizacion del tipo Basic con el BasicCredentialsProvider porque esta funcionando bien en todos los casos
 					HttpClientPrincipal p = (HttpClientPrincipal) en.nextElement();
-					this.credentialsProvider.setCredentials(
-						AuthScope.ANY,
-						new UsernamePasswordCredentials(p.user, p.password));
+					String auth = p.user + ":" + p.password;
+					String authHeader = "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.ISO_8859_1));
+					addHeader(HttpHeaders.PROXY_AUTHORIZATION, authHeader);
 				}
 
 				for (Enumeration en = getDigestProxyAuthorization().elements(); en.hasMoreElements(); ) {


### PR DESCRIPTION
For some reason, basic auth using httpclient lib is not behaving as the old implementation (which is the spected and seems to be the correct one).