### PR TITLE
Progress.hide() does not work when called from Static Progress EXO

### DIFF
--- a/common/src/main/java/com/genexus/diagnostics/UserLog.java
+++ b/common/src/main/java/com/genexus/diagnostics/UserLog.java
@@ -19,7 +19,8 @@ public class UserLog {
 	private static ILogger getLogger(String topic) {
 		ILogger log;
 		if (topic != null && topic.length() > 0) {
-			log = LogManager.getLogger(String.format("%s.%s", defaultUserLogNamespace, topic.trim()));
+			String loggerName = topic.startsWith("$") ? topic.substring(1): String.format("%s.%s", defaultUserLogNamespace, topic.trim());
+			log = LogManager.getLogger(loggerName);
 		}
 		else {
 			log = getMainLogger();

--- a/java/src/main/java/com/genexus/internet/GXWebProgressIndicator.java
+++ b/java/src/main/java/com/genexus/internet/GXWebProgressIndicator.java
@@ -27,14 +27,11 @@ public class GXWebProgressIndicator
 
         private void updateProgress()
         {
-			if (running)
-			{
-				GXWebNotificationInfo notif = new GXWebNotificationInfo(0,context,"");  
-				notif.setId(GXWebProgressIndicator.ID);
-				notif.setGroupName(GXWebProgressIndicator.ID);
-				notif.setMessage(info);          
-				notification.notify(notif);
-			}
+			GXWebNotificationInfo notif = new GXWebNotificationInfo(0,context,"");
+			notif.setId(GXWebProgressIndicator.ID);
+			notif.setGroupName(GXWebProgressIndicator.ID);
+			notif.setMessage(info);
+			notification.notify(notif);
         }
         
         public void showWithTitle(String title)

--- a/java/src/main/java/com/genexus/internet/GXWebProgressIndicator.java
+++ b/java/src/main/java/com/genexus/internet/GXWebProgressIndicator.java
@@ -8,8 +8,6 @@ public class GXWebProgressIndicator
         private GXWebNotification notification;        
         private GXWebProgressIndicatorInfo info;       
 		private ModelContext context;
-		private boolean running = false;
-		
 		
         public GXWebProgressIndicator(ModelContext gxContext)
         {
@@ -20,7 +18,6 @@ public class GXWebProgressIndicator
       
         public void show()
         {
-			running = true;
             setAction("0");
             updateProgress();
         }
@@ -36,7 +33,6 @@ public class GXWebProgressIndicator
         
         public void showWithTitle(String title)
         {
-			running = true;
             setTitle(title);
             setAction("1");
             updateProgress();
@@ -44,7 +40,6 @@ public class GXWebProgressIndicator
 
         public void showWithTitleAndDescription(String title, String desc)
         {
-			running = true;
             setTitle(title);
             setDescription(desc);
             setAction("2");
@@ -55,7 +50,6 @@ public class GXWebProgressIndicator
         {			
             setAction("3");
             updateProgress();
-			running = false;
         }
 
 		private String getAction() {


### PR DESCRIPTION
In WebApplications, Progress.Hide() does not work (because of Static Progress Usage):

```
Event Enter
   Progress.Show()
   &i = Sleep(4)
   Progress.Hide()
Endevent
```


Instead, this code works:
```
//do something that takes some time
&ProgressIndicator.ShowWithTitle("Executing action")
&ProgressIndicator.Hide()
```

Event Enter
   Progress.Show()
   &i = Sleep(4)
   Progress.Hide()
Endevent