### PR TITLE
RequestBody in a Rest request was stored in a threadLocal to get body…

### DIFF
--- a/java/src/main/java/com/genexus/GxRestService.java
+++ b/java/src/main/java/com/genexus/GxRestService.java
@@ -108,6 +108,7 @@ abstract public class GxRestService extends GXWebObjectBase
    	 GXutil.setThreadTimeZone(ModelContext.getModelContext().getClientTimeZone());
 	   super.cleanup();
 	   super.finallyCleanup();
+	   WrapperUtils.requestBodyThreadLocal.remove();
    }
 	
 	public void ErrorCheck(IGxSilentTrn trn)

--- a/java/src/main/java/com/genexus/internet/HttpRequestWeb.java
+++ b/java/src/main/java/com/genexus/internet/HttpRequestWeb.java
@@ -48,10 +48,13 @@ public class HttpRequestWeb extends HttpRequest
 			return messageBody;
 		}
 
-		String restRequestBody = WrapperUtils.requestBodyThreadLocal.get();
-		if (restRequestBody != null)
+		if (httpContext.isRestService())
 		{
-			return restRequestBody;
+			String restRequestBody = WrapperUtils.requestBodyThreadLocal.get();
+			if (restRequestBody != null)
+			{
+				return restRequestBody;
+			}
 		}
 		
 		try


### PR DESCRIPTION
… in a proc using httprequest.tostring(). The problem was that the threadLocal was not removed in the cleanup of the Rest request so another request that was not rest get the last rest body intead of its own body

Issue: 92346