### PR TITLE
Java keeps only new  httpclient implementation, the old one is not mo…

### DIFF
--- a/java/src/main/java/com/genexus/specific/java/HttpClient.java
+++ b/java/src/main/java/com/genexus/specific/java/HttpClient.java
@@ -4,9 +4,7 @@ import java.util.Hashtable;
 
 import com.genexus.CommonUtil;
 import com.genexus.common.interfaces.IExtensionHttpClient;
-import com.genexus.common.interfaces.SpecificImplementation;
 import com.genexus.internet.HttpClientJavaLib;
-import com.genexus.internet.HttpClientManual;
 
 import javax.net.ssl.SSLSocket;
 
@@ -39,26 +37,15 @@ public class HttpClient implements IExtensionHttpClient {
 
 	}
 
-	private com.genexus.internet.IHttpClient useHttpClientOldImplementation() {
-		com.genexus.internet.IHttpClient client = new HttpClientManual();
-		SpecificImplementation.HttpClient.initializeHttpClient(client);
-		return client;
-	}
-
 	@Override
 	public com.genexus.internet.IHttpClient initHttpClientImpl() {
 		com.genexus.internet.IHttpClient client = null;
 		try {
-
-			if (com.genexus.ResourceReader.getResourceAsStream("useoldhttpclient.txt") == null) {
-				Class.forName("org.apache.http.impl.conn.PoolingHttpClientConnectionManager");    // httpclient-4.5.14.jar dectected by reflection
-				client = new HttpClientJavaLib();
-			} else
-				client = useHttpClientOldImplementation();
+			Class.forName("org.apache.http.impl.conn.PoolingHttpClientConnectionManager");    // httpclient-4.5.14.jar dectected by reflection
+			client = new HttpClientJavaLib();
 
 		} catch (ClassNotFoundException e) {
-
-			client = useHttpClientOldImplementation();
+			System.err.println("HttpClient jars not detected. Check if httpclient-4.5.*.jar and httpcore-4.4.*.jar are added in the classpath");
 
 		} finally {
 


### PR DESCRIPTION
…re reacheable

The class HttpClientManual was kept because android is still using it. Besides, HttpClientJavaLib keeps extending GXHttpClient because in the future we may want to extend from here the new OkHttpClient that is being implemented