### PR TITLE
Excel Document: Multiple Merge cells not working

### DIFF
--- a/gxoffice/src/main/java/com/genexus/msoffice/excel/poi/xssf/ExcelCells.java
+++ b/gxoffice/src/main/java/com/genexus/msoffice/excel/poi/xssf/ExcelCells.java
@@ -897,7 +897,7 @@ public class ExcelCells implements IExcelCellRange {
         CellRangeAddress cellRange = new CellRangeAddress(rowStartIdx, rowEndIdx, colStartIdx, colEndIdx);
         for (int i = 0; i < pSelectedSheet.getNumMergedRegions(); i++){
             CellRangeAddress mergedRegion = pSelectedSheet.getMergedRegion(i);
-            if (cellRange.intersects(cellRange)){
+            if (cellRange.intersects(mergedRegion)){
                 pSelectedSheet.removeMergedRegion(i);
             }
         }

--- a/gxoffice/src/test/java/com/genexus/msoffice/excel/ExcelSpreadsheetTest.java
+++ b/gxoffice/src/test/java/com/genexus/msoffice/excel/ExcelSpreadsheetTest.java
@@ -618,6 +618,36 @@ public class ExcelSpreadsheetTest {
     }
 
 	@Test
+	public void testMergeMultipleCells() {
+		ExcelSpreadsheetGXWrapper excel = create("testMergeCells-2");
+		excel.getCells(1, 1, 2, 5).mergeCells();
+		excel.getCells(1, 1, 2, 5).setText("merged cells 1");
+
+		excel.getCells(5, 1, 2, 5).mergeCells();
+		excel.getCells(5, 1, 2, 5).setText("merged cells 2");
+
+		excel.getCells(8, 1, 2, 5).mergeCells();
+		excel.getCells(8, 1, 2, 5).setText("merged cells 3");
+
+		excel.save();
+		excel.close();
+	}
+
+	@Test
+	public void testMergeMultipleCellsIntersect() {
+		ExcelSpreadsheetGXWrapper excel = create("testMergeCells-3");
+		excel.getCells(1, 1, 8, 5).mergeCells();
+		excel.getCells(1, 1, 8, 5).setText("merged cells 1");
+
+		excel.getCells(5, 1, 8, 5).mergeCells();
+		excel.getCells(5, 1, 8, 5).setText("merged cells 2");
+
+		excel.save();
+		excel.close();
+	}
+
+
+	@Test
 	public void testMergeNestedCells() {
 		ExcelSpreadsheetGXWrapper excel = create("testMergeNestedCells");
 		excel.getCells(5, 5, 4, 4).mergeCells();


### PR DESCRIPTION
This code would not work:

```
&ExcelCellRange = &ExcelSpreadsheet.Cells(1,1,2,3)
&ExcelCellRange.Merge()
&ExcelCellRange = &ExcelSpreadsheet.Cells(5,1,2,3)
&ExcelCellRange.Merge()
&ExcelCellRange = &ExcelSpreadsheet.Cells(8,1,2,3)
&ExcelCellRange.Merge()
```

Only last merged cell would be retained. 

Issue 92657