### PR TITLE
Update Commons IO to 2.11 in Java, keeps 2.2 in Android

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -18,11 +18,23 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>gxcryptocommon</artifactId>
 			<version>${project.version}</version>
+            <exclusions>
+                <exclusion>  <!-- exclude common io from android -->
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>gxcommon</artifactId>
 			<version>${project.version}</version>
+            <exclusions>
+                <exclusion>  <!-- exclude common io from android -->
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.locationtech.spatial4j</groupId>
@@ -39,6 +51,14 @@
 			<artifactId>commons-collections4</artifactId>
 			<version>4.1</version>
 		</dependency>
+        <!-- add explicit common io in Android -->
+        <!-- Android need version 2.2 until api 26, where java.nio is added -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.2</version>
+        </dependency>
+
 	</dependencies>
 
 	<build>

--- a/androidreports/pom.xml
+++ b/androidreports/pom.xml
@@ -18,6 +18,12 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>gxcommon</artifactId>
 			<version>${project.version}</version>
+            <exclusions>
+                <exclusion>  <!-- exclude common io from android -->
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.2</version>
+			<version>2.11.0</version>
 		</dependency>		
 		<dependency>
 			<groupId>org.simpleframework</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.2</version>
+			<version>2.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/java/src/main/java/com/genexus/PrivateUtilities.java
+++ b/java/src/main/java/com/genexus/PrivateUtilities.java
@@ -25,6 +25,7 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
 import com.genexus.common.interfaces.SpecificImplementation;
+import com.genexus.internet.GXInternetConstants;
 import com.genexus.platform.NativeFunctions;
 import com.genexus.util.Codecs;
 import com.genexus.util.IniFile;
@@ -767,38 +768,64 @@ public final class PrivateUtilities
                 try { destination.close(); } catch (IOException e) { ; }
 	    }
 	}
-
+	public static String BOMInputStreamToStringUTF8(InputStream istream) {
+		if (istream == null) {
+			throw new IllegalArgumentException("BOMInputStreamToStringUTF8 -> Input stream can't be null");
+		}
+		boolean firstLine = true;
+		StringBuilder stringBuilder = new StringBuilder();
+		try (BufferedReader r = new BufferedReader(new InputStreamReader(istream, "UTF8"))) {
+			for (String s = ""; (s = r.readLine()) != null; ) {
+				if (firstLine) {
+					s = removeUTF8BOM(s);
+					firstLine = false;
+				}
+				stringBuilder.append(s + GXInternetConstants.CRLFString);
+			}
+			return stringBuilder.toString();
+		} catch (Exception e) {
+			System.err.println("Error reading stream:" + e.getMessage());
+			return "";
+		}
+	}
+	static final String UTF8_BOM = "\uFEFF";
+	private static String removeUTF8BOM(String s) {
+		if (s.startsWith(UTF8_BOM)) {
+			s = s.substring(1);
+		}
+		return s;
+	}
 
 	public static void InputStreamToFile(InputStream source, String fileName)
-	{
-		if	(source == null)
-		{
-			throw new IllegalArgumentException("InputStreamToFile -> Input stream can't be null");
-		}
+					{
+						if	(source == null)
+						{
+							throw new IllegalArgumentException("InputStreamToFile -> Input stream can't be null");
+						}
 
-		byte[] buffer;
-		int bytes_read;
-		OutputStream destination = null;
-		try 
-		{
-			destination = new BufferedOutputStream(new FileOutputStream(fileName));
-			buffer = new byte[1024];
-		 
-			while (true) 
-			{
-				bytes_read = source.read(buffer);
-				if (bytes_read == -1) break;
-				destination.write(buffer, 0, bytes_read);
-			}
-		}
-		catch (IOException e)
-		{
-			System.err.println("Error writing file " + fileName + ":" + e.getMessage());
-		}
-		finally 
-		{
-			if (source != null) 
-				try { source.close(); } catch (IOException e) { ; }
+						byte[] buffer;
+						int bytes_read;
+						OutputStream destination = null;
+						try
+						{
+							destination = new BufferedOutputStream(new FileOutputStream(fileName));
+							buffer = new byte[1024];
+
+							while (true)
+							{
+								bytes_read = source.read(buffer);
+								if (bytes_read == -1) break;
+								destination.write(buffer, 0, bytes_read);
+							}
+						}
+						catch (IOException e)
+						{
+							System.err.println("Error writing file " + fileName + ":" + e.getMessage());
+						}
+						finally
+						{
+							if (source != null)
+								try { source.close(); } catch (IOException e) { ; }
 			if (destination != null) 
 				try {destination.close(); } catch (IOException e) { ; }
 		}

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -1,12 +1,8 @@
 package com.genexus.internet;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.Date;
 import java.util.Enumeration;
-import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -17,8 +13,6 @@ import com.genexus.servlet.http.IHttpServletRequest;
 import com.genexus.servlet.http.IHttpServletResponse;
 
 import com.genexus.*;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.BOMInputStream;
 
 import com.genexus.usercontrols.UserControlFactoryImpl;
 import com.genexus.util.Codecs;
@@ -442,21 +436,20 @@ public abstract class HttpContext
 		if (cssContent == null)
 		{
 			String path = getRequest().getServletPath().replaceAll(".*/", "") + ".css";
-			try 
+			try(InputStream istream = context.packageClass.getResourceAsStream(path))
 			{
-				InputStream istream = context.packageClass.getResourceAsStream(path);
+
 				if (istream == null)
 				{
 					cssContent = "";
 				}
-				else
-				{
-					BOMInputStream bomInputStream = new BOMInputStream(istream);
-					cssContent = IOUtils.toString(bomInputStream, "UTF-8");
+				else {
+					//BOMInputStream bomInputStream = new BOMInputStream(istream);// Avoid using BOMInputStream because of runtime error (java.lang.NoSuchMethodError: org.apache.commons.io.IOUtils.length([Ljava/lang/Object;)I) issue 94611
+					//cssContent = IOUtils.toString(bomInputStream, "UTF-8");
+					cssContent = PrivateUtilities.BOMInputStreamToStringUTF8(istream);
 				}
 			}
-			catch ( Exception e)
-			{
+			catch ( Exception e) {
 				cssContent = "";
 			}
 			ApplicationContext.getcustomCSSContent().put(getRequest().getServletPath(), cssContent);

--- a/java/src/main/java/com/genexus/util/GXFile.java
+++ b/java/src/main/java/com/genexus/util/GXFile.java
@@ -763,8 +763,14 @@ public class GXFile extends AbstractGXFile {
             }
         }
         if (lineIterator != null) {
-            lineIterator.close();
-            lineIterator = null;
+           	try {
+				lineIterator.close();
+				lineIterator = null;
+			}
+			catch (java.io.IOException e) {
+				setUnknownError();
+				e.printStackTrace();
+			}
         }
     }
 }

--- a/java/src/main/java/com/genexus/webpanels/WebUtils.java
+++ b/java/src/main/java/com/genexus/webpanels/WebUtils.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import com.genexus.ModelContext;
 import com.genexus.internet.HttpContext;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.BOMInputStream;
 
 import com.genexus.CommonUtil;
 import com.genexus.GXutil;
@@ -518,8 +517,9 @@ public class WebUtils
 			InputStream is = getInputStreamFile(gxAppClass, servicesClassesFileName);
 			if (is != null)
 			{
-				BOMInputStream bomInputStream = new BOMInputStream(is);
-				String xmlstring = IOUtils.toString(bomInputStream, "UTF-8");
+				//BOMInputStream bomInputStream = new BOMInputStream(is);// Avoid using BOMInputStream because of runtime error (java.lang.NoSuchMethodError: org.apache.commons.io.IOUtils.length([Ljava/lang/Object;)I) issue 94611
+				//IOUtils.toString(bomInputStream, "UTF-8");
+				String xmlstring = PrivateUtilities.BOMInputStreamToStringUTF8(is);
 				
 				XMLReader reader = new XMLReader();
 				reader.openFromString(xmlstring);

--- a/wrappercommon/pom.xml
+++ b/wrappercommon/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.2</version>
+			<version>2.11.0</version>
 		</dependency>        			
 	</dependencies>	
 


### PR DESCRIPTION
Issue:
https://issues.genexus.com/viewissue.aspx?88708
Java - Dependencias con vulnerabilidades conocidas - commons-io

Se actualiza la version de CommonIO para Java para la version 2.11.0
En Android se mantiene la version 2.2  , necesaria para api < 26

Include SVN revision 156974
