### PR TITLE
[AWS Serverless] Handle Referer Header special case

### DIFF
--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
@@ -24,6 +24,7 @@ import com.genexus.util.IniFile;
 import com.genexus.webpanels.*;
 
 import java.util.Enumeration;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import com.amazonaws.serverless.proxy.internal.servlet.AwsProxyHttpServletResponseWriter;
@@ -73,6 +74,12 @@ public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyRe
 			MultiValuedTreeMap<String, String> qString = new MultiValuedTreeMap<>();
 			qString.add("", parmValue);
 			awsProxyRequest.setMultiValueQueryStringParameters(qString);
+		}
+
+		// In Jersey lambda context, the Referer Header has a special meaning. So we copy it to another Header.
+		List<String> referer = awsProxyRequest.getMultiValueHeaders().get("Referer");
+		if (referer != null && !referer.isEmpty()) {
+			awsProxyRequest.getMultiValueHeaders().put("GX-Referer", referer);
 		}
 	}
 


### PR DESCRIPTION
Referer Header is not working on Lambda because the "Referer" Header is being override by Jersey Lambda Container implementation.

In the future we should clone,  fork and publish a new Jersey Lambda Container implementation and remove this special behaviour, instead of copying the Header. 

This was needed urgently for TikTok LigaMX Angular App. 

