### PR TITLE
java.lang.NullPointerException for Serverless when Empty Headers

### DIFF
--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
@@ -24,6 +24,7 @@ import com.genexus.util.IniFile;
 import com.genexus.webpanels.*;
 
 import java.util.Enumeration;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import com.amazonaws.serverless.proxy.internal.servlet.AwsProxyHttpServletResponseWriter;
@@ -73,6 +74,12 @@ public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyRe
 			MultiValuedTreeMap<String, String> qString = new MultiValuedTreeMap<>();
 			qString.add("", parmValue);
 			awsProxyRequest.setMultiValueQueryStringParameters(qString);
+		}
+
+		// In Jersey lambda context, the Referer Header has a special meaning. So we copy it to another Header.
+		List<String> referer = awsProxyRequest.getMultiValueHeaders().get("Referer");
+		if (referer != null && !referer.isEmpty()) {
+			awsProxyRequest.getMultiValueHeaders().put("GX-Referer", referer);
 		}
 	}
 

--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
@@ -76,6 +76,9 @@ public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyRe
 			awsProxyRequest.setMultiValueQueryStringParameters(qString);
 		}
 
+		if (awsProxyRequest.getMultiValueHeaders() == null) {
+			return;
+		}
 		// In Jersey lambda context, the Referer Header has a special meaning. So we copy it to another Header.
 		List<String> referer = awsProxyRequest.getMultiValueHeaders().get("Referer");
 		if (referer != null && !referer.isEmpty()) {

--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/LambdaHandler.java
@@ -76,6 +76,10 @@ public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyRe
 			awsProxyRequest.setMultiValueQueryStringParameters(qString);
 		}
 
+
+		if (awsProxyRequest.getMultiValueHeaders() == null) {
+			return;
+		}
 		// In Jersey lambda context, the Referer Header has a special meaning. So we copy it to another Header.
 		List<String> referer = awsProxyRequest.getMultiValueHeaders().get("Referer");
 		if (referer != null && !referer.isEmpty()) {


### PR DESCRIPTION
When calling a Serverless function with NULL Http Headers (ex: using Fiddler only) an exception ocurred:


`java.lang.NullPointerException: java.lang.NullPointerExceptionjava.lang.NullPointerException	at com.genexus.cloud.serverless.aws.LambdaHandler.handleSpecialMethods(LambdaHandler.java:80)	at com.genexus.cloud.serverless.aws.LambdaHandler.handleRequest(LambdaHandler.java:57)	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)	at `
