### PR TITLE
When dtaddms is called with an Integer value is better to call dtadd …

### DIFF
--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -1378,6 +1378,8 @@ public final class CommonUtil
 
 	public static Date dtaddms(Date date, double seconds)
 	{
+		if (seconds % 1 == 0)
+			return dtadd(date, (int)seconds);
 		GregorianCalendar appGregorianCalendar = new GregorianCalendar(defaultTimeZone, defaultLocale);
 		appGregorianCalendar.setTime(date);
 		appGregorianCalendar.add(appGregorianCalendar.MILLISECOND, (int)Math.round(seconds * 1000));


### PR DESCRIPTION
…to avoid an overflow in the conversion to Integer

Issue: 94968