### PR TITLE
Bump jackson libraries from version 2.12.5 to version 2.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey.javax.version>2.34</jersey.javax.version>
         <jersey.jakarta.version>3.0.1</jersey.jakarta.version>
-        <jackson.version>2.12.5</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
         <junit.version>4.13.2</junit.version>
 	</properties>
 


### PR DESCRIPTION
Issue#95293
CVE-2020-36518
#GXSEC