### PR TITLE
Remove hardcoded DEFAULT datastore name

### DIFF
--- a/java/src/main/java/com/genexus/GXReorganization.java
+++ b/java/src/main/java/com/genexus/GXReorganization.java
@@ -246,7 +246,7 @@ System.err.println("Sigo...");
 					else
 						addMsg(msg.getMessage("GXM_reorgnotsuccess"));
 				}
-				Application.commit(context, getHandle(), "DEFAULT", null, "GXReorganization");
+				Application.commit(context, getHandle(),"GXReorganization");
 				if (!isOK)
 					System.exit(2);
 			}


### PR DESCRIPTION
Allow running reorg on a different datastore.
Issue:95224