### PR TITLE
Redis Exception: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class java.util.Vector

### DIFF
--- a/java/src/main/java/com/genexus/cache/redis/RedisClient.java
+++ b/java/src/main/java/com/genexus/cache/redis/RedisClient.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -79,7 +80,11 @@ public class RedisClient implements ICacheService2, Closeable {
 		pool = new JedisPool(new JedisPoolConfig(), host, port, redis.clients.jedis.Protocol.DEFAULT_TIMEOUT, password);
 
 		objMapper = new ObjectMapper();
-		objMapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+		objMapper
+			.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+			.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+			.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE)
+			.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.NONE);
 		objMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 		objMapper.enable(SerializationFeature.INDENT_OUTPUT);
 	}

--- a/java/src/main/java/com/genexus/cache/redis/RedisClient.java
+++ b/java/src/main/java/com/genexus/cache/redis/RedisClient.java
@@ -81,7 +81,6 @@ public class RedisClient implements ICacheService2, Closeable {
 		objMapper = new ObjectMapper();
 		objMapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
 		objMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-		objMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 		objMapper.enable(SerializationFeature.INDENT_OUTPUT);
 	}
 

--- a/java/src/main/java/com/genexus/cache/redis/RedisClient.java
+++ b/java/src/main/java/com/genexus/cache/redis/RedisClient.java
@@ -10,7 +10,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.apache.commons.lang.StringUtils;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/java/src/main/java/com/genexus/cache/redis/RedisClient.java
+++ b/java/src/main/java/com/genexus/cache/redis/RedisClient.java
@@ -81,6 +81,7 @@ public class RedisClient implements ICacheService2, Closeable {
 		objMapper = new ObjectMapper();
 		objMapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
 		objMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+		objMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 		objMapper.enable(SerializationFeature.INDENT_OUTPUT);
 	}
 

--- a/java/src/main/java/com/genexus/db/CacheValue.java
+++ b/java/src/main/java/com/genexus/db/CacheValue.java
@@ -55,7 +55,7 @@ public class CacheValue implements Serializable
 	}
 
 	public long getExpiryTimeMilliseconds()
-        {
+	{
 		return expiryTime*1000;
 	}
 	public int getExpiryTimeSeconds()
@@ -80,8 +80,8 @@ public class CacheValue implements Serializable
 	 */
 	public boolean hasExpired()
 	{
-            return (expiryHits > 0 && hits >= expiryHits) ||
-			   (expiryTime > 0 && (timestamp + (getExpiryTimeMilliseconds())) < System.currentTimeMillis());
+		return (expiryHits > 0 && hits >= expiryHits) ||
+			(expiryTime > 0 && (timestamp + (getExpiryTimeMilliseconds())) < System.currentTimeMillis());
 	}
 
 	private int []resultSetTypes;
@@ -155,8 +155,8 @@ public class CacheValue implements Serializable
 				case DynamicExecute.TYPE_DOUBLE: copy[i] = ((double[])resultSet[i]).clone(); break;
 				case DynamicExecute.TYPE_BOOLEAN: copy[i] = ((boolean[])resultSet[i]).clone(); break;
 				default:
-						copy[i] = ((Object[])resultSet[i]).clone();
-						System.arraycopy(resultSet[i], 0, copy[i], 0, 1);
+					copy[i] = ((Object[])resultSet[i]).clone();
+					System.arraycopy(resultSet[i], 0, copy[i], 0, 1);
 			}
 		}
 		CachedIFieldGetter cValue = new CachedIFieldGetter(copy);

--- a/java/src/main/java/com/genexus/db/CacheValue.java
+++ b/java/src/main/java/com/genexus/db/CacheValue.java
@@ -1,4 +1,6 @@
 package com.genexus.db;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.TimeZone;
@@ -173,8 +175,9 @@ public class CacheValue implements Serializable
 	public long getTimestamp()
 	{
 		return timestamp;
-	}	
-	//IFieldGetter iterator
+	}
+
+	@JsonIgnore
 	public Enumeration getIterator()
 	{
 		return items.elements();

--- a/java/src/main/java/com/genexus/db/CacheValue.java
+++ b/java/src/main/java/com/genexus/db/CacheValue.java
@@ -23,7 +23,7 @@ public class CacheValue implements Serializable
 
 	public CacheValue()
 	{
-	}
+	}	
 	public CacheValue(String sentence, Object [] parms)
 	{
 		if(parms == null)
@@ -37,15 +37,15 @@ public class CacheValue implements Serializable
 			key = new CacheKey(sentence, keyParms);
 		}
 		items = new Vector<CachedIFieldGetter>();
-
+		
 		cachedSize = sentence.length();
 	}
-
+	
 	public CacheKey getKey()
 	{
 		return key;
 	}
-
+	
 	/** Setea el tiempo de expiración (en segundos)
 	 *  o 0 para indicar que no expira por tiempo
 	 */
@@ -53,39 +53,39 @@ public class CacheValue implements Serializable
 	{
 		this.expiryTime = expiryTimeSeconds;
 	}
-
+	
 	public long getExpiryTimeMilliseconds()
-	{
+        {
 		return expiryTime*1000;
 	}
 	public int getExpiryTimeSeconds()
 	{
 		return expiryTime;
 	}
-
+	
 	/** Setea la cantidad de hits para expirar, o 0 si no
 	 * expira por cantidad de hits
-	 */
+	 */	
 	public void setExpiryHits(int expiryHits)
 	{
 		this.expiryHits = expiryHits;
 	}
-
+	
 	public int getExpiryHits()
 	{
 		return expiryHits;
-	}
-
+	}		
+	
 	/** Indica si este CacheValue ha expirado
 	 */
 	public boolean hasExpired()
 	{
-		return (expiryHits > 0 && hits >= expiryHits) ||
-			(expiryTime > 0 && (timestamp + (getExpiryTimeMilliseconds())) < System.currentTimeMillis());
+            return (expiryHits > 0 && hits >= expiryHits) || 
+			   (expiryTime > 0 && (timestamp + (getExpiryTimeMilliseconds())) < System.currentTimeMillis());
 	}
-
+	
 	private int []resultSetTypes;
-
+	
 	private void getResultSetTypes(Object [] resultSet)
 	{
 		resultSetTypes = new int[resultSet.length];
@@ -95,12 +95,12 @@ public class CacheValue implements Serializable
 			resultSetTypes[i] = DynamicExecute.getPrimitiveType(componentType);
 		}
 	}
-
-	public void setTimeZone(TimeZone cachedValueTimeZone)
+	
+	public void setTimeZone(TimeZone cachedValueTimeZone) 
 	{
 		mTimeZone = cachedValueTimeZone;
 	}
-
+	
 	protected void setIsRemote(boolean isRemote)
 	{
 		this.isRemote = isRemote;
@@ -127,11 +127,11 @@ public class CacheValue implements Serializable
 			items.addElement(new CachedIFieldGetter(values));
 		}
 	}
-
+	
 	public void addItem(Object [] resultSet, long thisSize)
 	{
 		cachedSize += thisSize + 8 * resultSet.length;
-
+		
 		// @HACK
 		// Tenemos que hacer un deep copy del resultSet
 		// pero como usamos tipos primitivos no podemos hacer el arrayCopy
@@ -140,7 +140,7 @@ public class CacheValue implements Serializable
 		if(resultSetTypes == null)
 		{
 			getResultSetTypes(resultSet);
-		}
+		}		
 		Object [] copy = (Object[])resultSet.clone();
 		for(int i = 0; i < resultSet.length; i++)
 		{
@@ -154,47 +154,47 @@ public class CacheValue implements Serializable
 				case DynamicExecute.TYPE_FLOAT: copy[i] = ((float[])resultSet[i]).clone(); break;
 				case DynamicExecute.TYPE_DOUBLE: copy[i] = ((double[])resultSet[i]).clone(); break;
 				case DynamicExecute.TYPE_BOOLEAN: copy[i] = ((boolean[])resultSet[i]).clone(); break;
-				default:
-					copy[i] = ((Object[])resultSet[i]).clone();
-					System.arraycopy(resultSet[i], 0, copy[i], 0, 1);
+				default: 
+						copy[i] = ((Object[])resultSet[i]).clone();
+						System.arraycopy(resultSet[i], 0, copy[i], 0, 1);
 			}
 		}
 		CachedIFieldGetter cValue = new CachedIFieldGetter(copy);
 		cValue.setTimeZone(mTimeZone);
 		items.addElement(cValue);
 	}
-
+	
 	public void setTimestamp()
 	{
 		timestamp = System.currentTimeMillis();
 		setTimeCreated(new java.util.Date());
 	}
-
+	
 	public long getTimestamp()
 	{
 		return timestamp;
-	}
+	}	
 	//IFieldGetter iterator
 	public Enumeration getIterator()
 	{
 		return items.elements();
 	}
-
+	
 	protected void incHits()
 	{
 		hits++;
 	}
-
+	
 	public int getHitCount()
 	{
 		return hits;
 	}
-
+	
 	protected int getCantItems()
 	{
 		return items.size();
 	}
-
+	
 	/** Retorna una estimación del 'tamaño' de este cacheValue
 	 *  En 2 capas, el tamaño del CacheValue lo contamos como la cantidad de filas
 	 *  multiplicado por la cantidad de columnas
@@ -204,16 +204,16 @@ public class CacheValue implements Serializable
 	{
 		return cachedSize;
 	}
-
+	
 	public java.util.Date getTimeCreated()
 	{
 		return timeCreated;
 	}
-
+	
 	public void setTimeCreated(java.util.Date timeCreated)
 	{
 		this.timeCreated = timeCreated;
-	}
-
-
+	}	
+	
+	
 }

--- a/java/src/main/java/com/genexus/db/CacheValue.java
+++ b/java/src/main/java/com/genexus/db/CacheValue.java
@@ -1,6 +1,4 @@
 package com.genexus.db;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.TimeZone;
@@ -25,7 +23,7 @@ public class CacheValue implements Serializable
 
 	public CacheValue()
 	{
-	}	
+	}
 	public CacheValue(String sentence, Object [] parms)
 	{
 		if(parms == null)
@@ -39,15 +37,15 @@ public class CacheValue implements Serializable
 			key = new CacheKey(sentence, keyParms);
 		}
 		items = new Vector<CachedIFieldGetter>();
-		
+
 		cachedSize = sentence.length();
 	}
-	
+
 	public CacheKey getKey()
 	{
 		return key;
 	}
-	
+
 	/** Setea el tiempo de expiración (en segundos)
 	 *  o 0 para indicar que no expira por tiempo
 	 */
@@ -55,7 +53,7 @@ public class CacheValue implements Serializable
 	{
 		this.expiryTime = expiryTimeSeconds;
 	}
-	
+
 	public long getExpiryTimeMilliseconds()
         {
 		return expiryTime*1000;
@@ -64,30 +62,30 @@ public class CacheValue implements Serializable
 	{
 		return expiryTime;
 	}
-	
+
 	/** Setea la cantidad de hits para expirar, o 0 si no
 	 * expira por cantidad de hits
-	 */	
+	 */
 	public void setExpiryHits(int expiryHits)
 	{
 		this.expiryHits = expiryHits;
 	}
-	
+
 	public int getExpiryHits()
 	{
 		return expiryHits;
-	}		
-	
+	}
+
 	/** Indica si este CacheValue ha expirado
 	 */
 	public boolean hasExpired()
 	{
-            return (expiryHits > 0 && hits >= expiryHits) || 
+            return (expiryHits > 0 && hits >= expiryHits) ||
 			   (expiryTime > 0 && (timestamp + (getExpiryTimeMilliseconds())) < System.currentTimeMillis());
 	}
-	
+
 	private int []resultSetTypes;
-	
+
 	private void getResultSetTypes(Object [] resultSet)
 	{
 		resultSetTypes = new int[resultSet.length];
@@ -97,12 +95,12 @@ public class CacheValue implements Serializable
 			resultSetTypes[i] = DynamicExecute.getPrimitiveType(componentType);
 		}
 	}
-	
-	public void setTimeZone(TimeZone cachedValueTimeZone) 
+
+	public void setTimeZone(TimeZone cachedValueTimeZone)
 	{
 		mTimeZone = cachedValueTimeZone;
 	}
-	
+
 	protected void setIsRemote(boolean isRemote)
 	{
 		this.isRemote = isRemote;
@@ -129,11 +127,11 @@ public class CacheValue implements Serializable
 			items.addElement(new CachedIFieldGetter(values));
 		}
 	}
-	
+
 	public void addItem(Object [] resultSet, long thisSize)
 	{
 		cachedSize += thisSize + 8 * resultSet.length;
-		
+
 		// @HACK
 		// Tenemos que hacer un deep copy del resultSet
 		// pero como usamos tipos primitivos no podemos hacer el arrayCopy
@@ -142,7 +140,7 @@ public class CacheValue implements Serializable
 		if(resultSetTypes == null)
 		{
 			getResultSetTypes(resultSet);
-		}		
+		}
 		Object [] copy = (Object[])resultSet.clone();
 		for(int i = 0; i < resultSet.length; i++)
 		{
@@ -156,7 +154,7 @@ public class CacheValue implements Serializable
 				case DynamicExecute.TYPE_FLOAT: copy[i] = ((float[])resultSet[i]).clone(); break;
 				case DynamicExecute.TYPE_DOUBLE: copy[i] = ((double[])resultSet[i]).clone(); break;
 				case DynamicExecute.TYPE_BOOLEAN: copy[i] = ((boolean[])resultSet[i]).clone(); break;
-				default: 
+				default:
 						copy[i] = ((Object[])resultSet[i]).clone();
 						System.arraycopy(resultSet[i], 0, copy[i], 0, 1);
 			}
@@ -165,39 +163,38 @@ public class CacheValue implements Serializable
 		cValue.setTimeZone(mTimeZone);
 		items.addElement(cValue);
 	}
-	
+
 	public void setTimestamp()
 	{
 		timestamp = System.currentTimeMillis();
 		setTimeCreated(new java.util.Date());
 	}
-	
+
 	public long getTimestamp()
 	{
 		return timestamp;
 	}
-
-	@JsonIgnore
+	//IFieldGetter iterator
 	public Enumeration getIterator()
 	{
 		return items.elements();
 	}
-	
+
 	protected void incHits()
 	{
 		hits++;
 	}
-	
+
 	public int getHitCount()
 	{
 		return hits;
 	}
-	
+
 	protected int getCantItems()
 	{
 		return items.size();
 	}
-	
+
 	/** Retorna una estimación del 'tamaño' de este cacheValue
 	 *  En 2 capas, el tamaño del CacheValue lo contamos como la cantidad de filas
 	 *  multiplicado por la cantidad de columnas
@@ -207,16 +204,16 @@ public class CacheValue implements Serializable
 	{
 		return cachedSize;
 	}
-	
+
 	public java.util.Date getTimeCreated()
 	{
 		return timeCreated;
 	}
-	
+
 	public void setTimeCreated(java.util.Date timeCreated)
 	{
 		this.timeCreated = timeCreated;
-	}	
-	
-	
+	}
+
+
 }

--- a/java/src/test/java/com/genexus/cache/redis/TestRedisCacheClient.java
+++ b/java/src/test/java/com/genexus/cache/redis/TestRedisCacheClient.java
@@ -1,5 +1,6 @@
 package com.genexus.cache.redis;
 
+import com.genexus.db.CacheValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.genexus.specific.java.Connect;
@@ -100,11 +101,25 @@ public class TestRedisCacheClient {
 		redis.set(cacheId, cacheKey, cacheValue);
 
 		String obtainedValue = redis.get(cacheId, cacheKey, String.class);
-
 		Assert.assertEquals(obtainedValue, cacheValue);
-
-
-
 	}
+
+	@Test
+	public void testSetCacheValueRedis()
+	{
+		Connect.init();
+
+		RedisClient redis = getRedisClient("", "");
+		Assert.assertNotNull("Redis instance could not be created", redis);
+
+		String cacheId = "TEST";
+		String cacheKey = "TEST_KEY";
+		CacheValue c = new CacheValue("SELECT * FROM User;", new Object[] { 1, 2, 3});
+		c.addItem(123);
+		redis.set(cacheId, cacheKey, c);
+		CacheValue obtainedValue = redis.get(cacheId, cacheKey, CacheValue.class);
+		Assert.assertNotNull(obtainedValue);
+	}
+
 
 }

--- a/java/src/test/java/com/genexus/cache/redis/TestRedisCacheClient.java
+++ b/java/src/test/java/com/genexus/cache/redis/TestRedisCacheClient.java
@@ -11,6 +11,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import java.net.URISyntaxException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assume.assumeTrue;
 
@@ -96,7 +97,7 @@ public class TestRedisCacheClient {
 		Assert.assertNotNull("Redis instance could not be created", redis);
 
 		String cacheId = "TEST";
-		String cacheKey = "TEST_KEY";
+		String cacheKey = "TEST_KEY" + ThreadLocalRandom.current().nextInt();
 		String cacheValue = "KeyValue";
 		redis.set(cacheId, cacheKey, cacheValue);
 
@@ -112,8 +113,8 @@ public class TestRedisCacheClient {
 		RedisClient redis = getRedisClient("", "");
 		Assert.assertNotNull("Redis instance could not be created", redis);
 
-		String cacheId = "TEST";
-		String cacheKey = "TEST_KEY";
+		String cacheId = "TEST"+ ThreadLocalRandom.current().nextInt();
+		String cacheKey = "TEST_KEY" + ThreadLocalRandom.current().nextInt();
 		CacheValue c = new CacheValue("SELECT * FROM User;", new Object[] { 1, 2, 3});
 		c.addItem(123);
 		redis.set(cacheId, cacheKey, c);


### PR DESCRIPTION
- Only serialize Class Fields (Not methods)
- Added UnitTesting for CacheValue, structure that is used in the generated GeneXus WebApps. 


```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class java.util.Vector$1 and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: com.genexus.db.CacheValue["iterator"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1300) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:400) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.failForEmpty(UnknownSerializer.java:46) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.serialize(UnknownSerializer.java:29) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:728) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4568) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3821) ~[jackson-databind-2.13.2.1.jar:2.13.2.1]
	at com.genexus.cache.redis.RedisClient.set(RedisClient.java:106) [gxclassR.jar:?]
	at com.genexus.cache.redis.RedisClient.set(RedisClient.java:185) [gxclassR.jar:?]
	at com.genexus.db.DataStoreProvider.close(DataStoreProvider.java:562) [gxclassR.jar:?]
	at com.testdbaccesscaching.atestcache2.privateExecute(atestcache2.java:136) [web/:?]
	at com.testdbaccesscaching.atestcache2.execute_int(atestcache2.java:54) [web/:?]
	at com.testdbaccesscaching.atestcache2.execute(atestcache2.java:46) [web/:?]
	at com.testdbaccesscaching.atestcache2.executeCmdLine(atestcache2.java:30) [web/:?]
```