### PR TITLE
Stop encoding < which is not a special character for a json value

### DIFF
--- a/common/src/main/java/json/org/json/JSONObject.java
+++ b/common/src/main/java/json/org/json/JSONObject.java
@@ -963,12 +963,6 @@ public class JSONObject implements IJsonFormattable, java.io.Serializable{
                 sb.append('\\');
                 sb.append(c);
                 break;
-            case '/':
-                if (b == '<') {
-                    sb.append('\\');
-                }
-                sb.append(c);
-                break;
             case '\b':
                 sb.append("\\b");
                 break;


### PR DESCRIPTION
According to json spec https://www.json.org/json-en.html the character '<' is not a special character to be escaped.