### PR TITLE
Use same AWS SDK version for all child Projects 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <jersey.jakarta.version>3.0.1</jersey.jakarta.version>
         <jackson.version>2.13.2</jackson.version>
         <junit.version>4.13.2</junit.version>
+        <software.awssdk.version>2.17.213</software.awssdk.version>
 	</properties>
 
     <modules>


### PR DESCRIPTION
Use same AWS SDK version for all child Projects as:
- gxdynamodb
- aws sqs

Child projects are still in PR, so not in master branch. We need this property to go into master so every open PR can use it. 
