### PR TITLE
Add CORS Headers to JAX Webservice Responses when Environment Variable is Present

### DIFF
--- a/wrappercommon/src/main/java/com/genexus/cors/CORSHelper.java
+++ b/wrappercommon/src/main/java/com/genexus/cors/CORSHelper.java
@@ -1,0 +1,32 @@
+package com.genexus.cors;
+
+import java.util.HashMap;
+
+public class CORSHelper {
+	private static String CORS_ALLOWED_ORIGINS_ENV_VAR_NAME = "GX_CORS_ALLOW_ORIGIN";
+	private static String CORS_MAX_AGE_SECONDS = "86400";
+	private static String CORS_ALLOWED_METHODS = "GET, POST, PUT, DELETE, OPTIONS, HEAD";
+	private static String CORS_ALLOWED_HEADERS = "*";
+
+	public static HashMap<String, String> getCORSHeaders() {
+		String corsAllowedOrigin = System.getenv(CORS_ALLOWED_ORIGINS_ENV_VAR_NAME);
+		if (corsAllowedOrigin == null || corsAllowedOrigin.isEmpty()) {
+			return null;
+		}
+		HashMap<String, String> corsHeaders = new HashMap<>();
+		corsHeaders.put(
+			"Access-Control-Allow-Origin", corsAllowedOrigin);
+		corsHeaders.put(
+			"Access-Control-Allow-Credentials", "true");
+		corsHeaders.put(
+			"Access-Control-Allow-Headers",
+			CORS_ALLOWED_HEADERS);
+		corsHeaders.put(
+			"Access-Control-Allow-Methods",
+			CORS_ALLOWED_METHODS);
+		corsHeaders.put(
+			"Access-Control-Max-Age",
+			CORS_MAX_AGE_SECONDS);
+		return corsHeaders;
+	}
+}

--- a/wrappercommon/src/main/java/com/genexus/cors/CORSHelper.java
+++ b/wrappercommon/src/main/java/com/genexus/cors/CORSHelper.java
@@ -5,10 +5,10 @@ import java.util.HashMap;
 public class CORSHelper {
 	private static String CORS_ALLOWED_ORIGINS_ENV_VAR_NAME = "GX_CORS_ALLOW_ORIGIN";
 	private static String CORS_MAX_AGE_SECONDS = "86400";
-	private static String CORS_ALLOWED_METHODS = "GET, POST, PUT, DELETE, OPTIONS, HEAD";
+	private static String CORS_ALLOWED_METHODS = "GET, POST, PUT, DELETE, HEAD";
 	private static String CORS_ALLOWED_HEADERS = "*";
 
-	public static HashMap<String, String> getCORSHeaders() {
+	public static HashMap<String, String> getCORSHeaders(String requestRequiredHeaders) {
 		String corsAllowedOrigin = System.getenv(CORS_ALLOWED_ORIGINS_ENV_VAR_NAME);
 		if (corsAllowedOrigin == null || corsAllowedOrigin.isEmpty()) {
 			return null;
@@ -18,9 +18,11 @@ public class CORSHelper {
 			"Access-Control-Allow-Origin", corsAllowedOrigin);
 		corsHeaders.put(
 			"Access-Control-Allow-Credentials", "true");
+
 		corsHeaders.put(
 			"Access-Control-Allow-Headers",
-			CORS_ALLOWED_HEADERS);
+			requestRequiredHeaders == null || requestRequiredHeaders.isEmpty() ? CORS_ALLOWED_HEADERS : requestRequiredHeaders);
+
 		corsHeaders.put(
 			"Access-Control-Allow-Methods",
 			CORS_ALLOWED_METHODS);

--- a/wrapperjakarta/src/main/java/com/genexus/servlet/CorsFilter.java
+++ b/wrapperjakarta/src/main/java/com/genexus/servlet/CorsFilter.java
@@ -1,0 +1,46 @@
+package com.genexus.servlet;
+
+
+import com.genexus.cors.CORSHelper;
+import jakarta.servlet.*;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class CorsFilter implements jakarta.servlet.Filter {
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		Filter.super.init(filterConfig);
+	}
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+		HttpServletRequest request = (HttpServletRequest) servletRequest;
+
+		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders(request.getHeader("Access-Control-Request-Headers"));
+		if (corsHeaders != null) {
+			HttpServletResponse response = (HttpServletResponse) servletResponse;
+			for (String headerName : corsHeaders.keySet()) {
+				if (!response.containsHeader(headerName)) {
+					response.setHeader(headerName, corsHeaders.get(headerName));
+				}
+			}
+		}
+		if (!request.getMethod().equalsIgnoreCase("OPTIONS")) {
+			filterChain.doFilter(servletRequest, servletResponse);
+		}
+	}
+
+	@Override
+	public void destroy() {
+		Filter.super.destroy();
+	}
+}

--- a/wrapperjakarta/src/main/java/com/genexus/servlet/CorsFilter.java
+++ b/wrapperjakarta/src/main/java/com/genexus/servlet/CorsFilter.java
@@ -18,7 +18,7 @@ public class CorsFilter implements jakarta.servlet.Filter {
 
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
-		Filter.super.init(filterConfig);
+
 	}
 
 	@Override
@@ -41,6 +41,6 @@ public class CorsFilter implements jakarta.servlet.Filter {
 
 	@Override
 	public void destroy() {
-		Filter.super.destroy();
+
 	}
 }

--- a/wrapperjakarta/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
+++ b/wrapperjakarta/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
@@ -5,6 +5,8 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.ext.Provider;
+
+import java.util.Collections;
 import java.util.HashMap;
 
 @Provider
@@ -17,9 +19,7 @@ public class JAXRSCorsFilter implements ContainerResponseFilter {
 			return;
 		}
 		for (String headerName : corsHeaders.keySet()) {
-			if (!responseContext.getHeaders().containsKey(headerName)) {
-				responseContext.getHeaders().add(headerName, corsHeaders.get(headerName));
-			}
+			responseContext.getHeaders().putSingle(headerName,corsHeaders.get(headerName));
 		}
 	}
 }

--- a/wrapperjakarta/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
+++ b/wrapperjakarta/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
@@ -1,0 +1,25 @@
+package com.genexus.ws;
+
+import com.genexus.cors.CORSHelper;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import java.util.HashMap;
+
+@Provider
+public class JAXRSCorsFilter implements ContainerResponseFilter {
+	@Override
+	public void filter(ContainerRequestContext requestContext,
+					   ContainerResponseContext responseContext) {
+		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders();
+		if (corsHeaders == null) {
+			return;
+		}
+		for (String headerName : corsHeaders.keySet()) {
+			if (!responseContext.getHeaders().containsKey(headerName)) {
+				responseContext.getHeaders().add(headerName, corsHeaders.get(headerName));
+			}
+		}
+	}
+}

--- a/wrapperjakarta/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
+++ b/wrapperjakarta/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
@@ -12,7 +12,7 @@ public class JAXRSCorsFilter implements ContainerResponseFilter {
 	@Override
 	public void filter(ContainerRequestContext requestContext,
 					   ContainerResponseContext responseContext) {
-		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders();
+		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders(requestContext.getHeaderString("Access-Control-Request-Headers"));
 		if (corsHeaders == null) {
 			return;
 		}

--- a/wrapperjavax/src/main/java/com/genexus/servlet/CorsFilter.java
+++ b/wrapperjavax/src/main/java/com/genexus/servlet/CorsFilter.java
@@ -1,0 +1,43 @@
+package com.genexus.servlet;
+
+import com.genexus.cors.CORSHelper;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class CorsFilter implements Filter {
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+
+	}
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+		HttpServletRequest request = (HttpServletRequest) servletRequest;
+		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders(request.getHeader("Access-Control-Request-Headers"));
+		if (corsHeaders != null) {
+			HttpServletResponse response = (HttpServletResponse) servletResponse;
+			for (String headerName : corsHeaders.keySet()) {
+				if (!response.containsHeader(headerName)) {
+					response.setHeader(headerName, corsHeaders.get(headerName));
+				}
+			}
+		}
+		if (!request.getMethod().equalsIgnoreCase("OPTIONS")) {
+			filterChain.doFilter(servletRequest, servletResponse);
+		}
+	}
+
+	@Override
+	public void destroy() {
+
+	}
+}

--- a/wrapperjavax/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
+++ b/wrapperjavax/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
@@ -6,6 +6,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
+import java.util.Collections;
 import java.util.HashMap;
 
 @Provider
@@ -19,9 +20,7 @@ public class JAXRSCorsFilter implements ContainerResponseFilter {
 			return;
 		}
 		for (String headerName : corsHeaders.keySet()) {
-			if (!responseContext.getHeaders().containsKey(headerName)) {
-				responseContext.getHeaders().add(headerName, corsHeaders.get(headerName));
-			}
+			responseContext.getHeaders().putSingle(headerName,corsHeaders.get(headerName));
 		}
 	}
 }

--- a/wrapperjavax/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
+++ b/wrapperjavax/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
@@ -14,7 +14,7 @@ public class JAXRSCorsFilter implements ContainerResponseFilter {
 	@Override
 	public void filter(ContainerRequestContext requestContext,
 					   ContainerResponseContext responseContext) {
-		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders();
+		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders(requestContext.getHeaderString("Access-Control-Request-Headers"));
 		if (corsHeaders == null) {
 			return;
 		}

--- a/wrapperjavax/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
+++ b/wrapperjavax/src/main/java/com/genexus/ws/JAXRSCorsFilter.java
@@ -1,0 +1,27 @@
+package com.genexus.ws;
+
+import com.genexus.cors.CORSHelper;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.util.HashMap;
+
+@Provider
+public class JAXRSCorsFilter implements ContainerResponseFilter {
+
+	@Override
+	public void filter(ContainerRequestContext requestContext,
+					   ContainerResponseContext responseContext) {
+		HashMap<String, String> corsHeaders = CORSHelper.getCORSHeaders();
+		if (corsHeaders == null) {
+			return;
+		}
+		for (String headerName : corsHeaders.keySet()) {
+			if (!responseContext.getHeaders().containsKey(headerName)) {
+				responseContext.getHeaders().add(headerName, corsHeaders.get(headerName));
+			}
+		}
+	}
+}


### PR DESCRIPTION
When EnvironmentVariable "GX_CORS_ALLOW_ORIGIN" is present, GeneXus Will return CORS Http Headers in Webservices (JAXRS) responses.

This is needed for Angular Applications that are hosted in different http domains.

We use only EnviromentVariables, as this the use case is when Apps are deployed contenerized. 


Also, added Servlet Filters for old plain Webservices (GAM OauthServices) that are served via Servlets instead of JAXWS Infrastructure. Unfortunately, this is needed until we get rid of the http servlets webservice of GAM. 

Issue: 96724