### PR TITLE
Autorelease when publishing to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
 						<configuration>
 							<serverId>ossrh</serverId>
 							<nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
-							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+							<autoReleaseAfterClose>true</autoReleaseAfterClose>
 						</configuration>
 					</plugin>
 				 </plugins>


### PR DESCRIPTION
Given that a manual release of the packages was successful, releases should now be automatic for release builds.

Issue:97726