### PR TITLE
Unify AWS SDK Version for DynamoDB & SQS Queue & Bump to latest version

### DIFF
--- a/gxdynamodb/pom.xml
+++ b/gxdynamodb/pom.xml
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.151</version>
+                <version>${software.awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/gxexternalproviders/pom.xml
+++ b/gxexternalproviders/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.93</version>
+            <version>${com.amazonaws.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <poi.version>5.2.2</poi.version>
         <jackson.version>2.13.2</jackson.version>
         <junit.version>4.13.2</junit.version>
+        <com.amazonaws.version>1.12.93</com.amazonaws.version>
         <software.awssdk.version>2.17.213</software.awssdk.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <jackson.version>2.13.2</jackson.version>
         <junit.version>4.13.2</junit.version>
         <com.amazonaws.version>1.12.93</com.amazonaws.version>
-        <software.awssdk.version>2.17.213</software.awssdk.version>
+        <software.awssdk.version>2.17.272</software.awssdk.version>
     </properties>
 
 	<organization>


### PR DESCRIPTION
- Use same AWS SDK Version.
- Add pom property variable to AWS S3. 
- Bump AWS SDK latest version