### PR TITLE
HttpClient Runtime exception: java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -136,12 +136,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-logging</artifactId>
-                    <groupId>commons-logging</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>		
 		<dependency>
     		<groupId>com.sun.org.apache.xml.internal</groupId>


### PR DESCRIPTION
Restore excluded dependency for ApacheClient.

```
Caused by: java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory
at org.apache.http.conn.ssl.AbstractVerifier.<init>(AbstractVerifier.java:61) ~[httpclient-4.5.13.jar:4.5.13]
at org.apache.http.conn.ssl.AllowAllHostnameVerifier.<init>(AllowAllHostnameVerifier.java:44) ~[httpclient-4.5.13.jar:4.5.13]
at org.apache.http.conn.ssl.AllowAllHostnameVerifier.<clinit>(AllowAllHostnameVerifier.java:46) ~[httpclient-4.5.13.jar:4.5.13]
at org.apache.http.conn.ssl.SSLConnectionSocketFactory.<clinit>(SSLConnectionSocketFactory.java:151) ~[httpclient-4.5.13.jar:4.5.13]
at com.genexus.internet.HttpClientJavaLib.getSSLSecureInstance(HttpClientJavaLib.java:242) ~[gxclassR-2.8-SNAPSHOT.jar:?]
at com.genexus.internet.HttpClientJavaLib.getPoolInstance(HttpClientJavaLib.java:77) ~[gxclassR-2.8-SNAPSHOT.jar:?]
at com.genexus.internet.HttpClientJavaLib.<init>(HttpClientJavaLib.java:59) ~[gxclassR-2.8-SNAPSHOT.jar:?]
at com.genexus.specific.java.HttpClient.initHttpClientImpl(HttpClient.java:61) ~[gxclassR-2.8-SNAPSHOT.jar:?]
```