### PR TITLE
Runtime.GetEnvironmentVariable() crash when Environment Variable is not defined

### DIFF
--- a/common/src/main/java/com/genexus/GXRuntime.java
+++ b/common/src/main/java/com/genexus/GXRuntime.java
@@ -1,49 +1,53 @@
 package com.genexus;
 
-import com.genexus.util.*;
+import com.genexus.util.GXProperties;
 import java.util.Map;
 
 public class GXRuntime {
-  static public short getEnvironment() {
-    return 1; // RuntimeEnvironment.Server
-  }
-  static int exitCode;
 
-  static public void exit() {
-	if (exitCode!=0){
-		System.exit(exitCode);
-	 }
-  }
-  static public void setExitCode(int value) {
-    exitCode = value; 
-  }
-  static public int getExitCode() {
-    return exitCode; 
-  }
-
-  public static String GetEnvironmentVariable(String key) {
-  	String value = "";
-  	if (key != null && key.length() > 0){
-		value = System.getenv(key);
-	}
-  		return value;
-  }
-  public static GXProperties GetEnvironmentVariables() {
-
-	  Map<String, String> env = System.getenv();
-	  GXProperties gxProperties = new GXProperties();
-	  for (String envName : env.keySet()) {
-		  gxProperties.add(envName,env.get(envName) );
-	  }
-	  return gxProperties;
+	static public short getEnvironment() {
+		return 1; // RuntimeEnvironment.Server
 	}
 
-  public static boolean HasEnvironmentVariable(String key) {
-  	if (key != null && key.length() > 0){
-  		String value = System.getenv(key);
-  		if (value != null && value.length() > 0)
-  			return true;
-  	}
-  	return false;
-  }
+	static int exitCode;
+
+	static public void exit() {
+		if (exitCode != 0) {
+			System.exit(exitCode);
+		}
+	}
+
+	static public void setExitCode(int value) {
+		exitCode = value;
+	}
+
+	static public int getExitCode() {
+		return exitCode;
+	}
+
+	public static String GetEnvironmentVariable(String key) {
+		if (key == null || key.isEmpty()) {
+			return "";
+		}
+
+		String value = System.getenv(key);
+		return value == null ? "" : value;
+	}
+
+	public static GXProperties GetEnvironmentVariables() {
+		Map<String, String> env = System.getenv();
+		GXProperties gxProperties = new GXProperties();
+		for (String envName : env.keySet()) {
+			gxProperties.add(envName, env.get(envName));
+		}
+		return gxProperties;
+	}
+
+	public static boolean HasEnvironmentVariable(String key) {
+		if (key == null || key.isEmpty()) {
+			return false;
+		}
+
+		return System.getenv(key) != null;
+	}
 }


### PR DESCRIPTION
This code will crash in JAVA, when the ENV_VAR is not defined:

```
&GxCorsEnvironmentVar = Runtime.GetEnvironmentVariable(!"GX_CORS_ALLOW_ORIGIN")
msg(&GxCorsEnvironmentVar.ToString())
```

Also:
- Fix code formatting
- Fix HasEnvironmentVariable returning false if ENVVar = "". 