### PR TITLE
Fix sintax error in embedded css using @import

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -543,7 +543,7 @@ public abstract class HttpContext
 				if (isGxThemeHidden)
 					writeTextNL("<link id=\"gxtheme_css_reference\" " + sRelAtt + " type=\"text/css\" href=\"" + sUncachedURL + "\" " + htmlEndTag(HTMLElement.LINK));
 				else
-					writeTextNL("<style data-gx-href=\""+ sUncachedURL + "\"> @import url(\"" + sUncachedURL + "\") layer(" + sLayerName + ") </style>");
+					writeTextNL("<style data-gx-href=\""+ sUncachedURL + "\"> @import url(\"" + sUncachedURL + "\") layer(" + sLayerName + ");</style>");
 			}
 			else
 			{


### PR DESCRIPTION
Fix sintax error at embedded css @import  