### PR TITLE
Avoid XSS Security Issues due to SPA redirects

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -22,6 +22,7 @@ import com.genexus.util.ThemeHelper;
 import com.genexus.webpanels.GXWebObjectBase;
 import com.genexus.webpanels.WebSession;
 
+import com.genexus.webpanels.WebUtils;
 import json.org.json.IJsonFormattable;
 import json.org.json.JSONArray;
 import json.org.json.JSONException;
@@ -943,7 +944,7 @@ public abstract class HttpContext
 		AddStylesheetsToLoad();
 		if (isSpaRequest())
 		{
-			writeTextNL("<script>gx.ajax.saveJsonResponse(" + getJSONResponse() + ");</script>");
+			writeTextNL("<script>gx.ajax.saveJsonResponse(" + WebUtils.htmlEncode(JSONObject.quote(getJSONResponse()), true) + ");</script>");
 		}
 		else
 		{				


### PR DESCRIPTION
Do not send raw json unencoded to client because some html special characters will break SinglePage Application parsing introducing possible XSS attacks. 

Issue: 99580