### PR TITLE
HttpClient URL crashed when white spaces within URL

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
+++ b/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
@@ -9,8 +9,6 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
-
-import HTTPClient.ParseException;
 import com.genexus.ModelContext;
 import com.genexus.util.IniFile;
 import org.apache.http.*;
@@ -184,14 +182,26 @@ public class HttpClientJavaLib extends GXHttpClient {
 		}
 		catch (URISyntaxException e)
 		{
-			logger.error(String.format("Could not setURL '%s'", stringURL), e);
+			System.err.println("E " + e + " " + stringURL);
+			e.printStackTrace();
 		}
 	}
 
+	private String escapeInvalidUrlChars(String rawUrl) {
+		return rawUrl.replaceAll(" ", "%20");
+	}
+
 	private String getURLValid(String url) {
+		URI uri;
 		try
 		{
-			URI uri = new URI(url);
+			try {
+				uri = new URI(url);
+			}
+			catch (URISyntaxException e) {
+				url = escapeInvalidUrlChars(url);
+				uri = new URI(url);
+			}
 			if (!uri.isAbsolute())		// En caso que la URL pasada por parametro no sea una URL valida (en este caso seria que no sea un URL absoluta), salta una excepcion en esta linea, y se continua haciendo todo el proceso con los datos ya guardados como atributos
 				return url;
 			else {
@@ -204,10 +214,10 @@ public class HttpClientJavaLib extends GXHttpClient {
 
 				StringBuilder relativeUri = new StringBuilder();
 				if (uri.getPath() != null) {
-					relativeUri.append(uri.getPath());
+					relativeUri.append(uri.getRawPath());
 				}
 				if (uri.getQuery() != null) {
-					relativeUri.append('?').append(uri.getQuery());
+					relativeUri.append('?').append(uri.getRawQuery());
 				}
 				if (uri.getFragment() != null) {
 					relativeUri.append('#').append(uri.getFragment());
@@ -216,40 +226,6 @@ public class HttpClientJavaLib extends GXHttpClient {
 			}
 		}
 		catch (URISyntaxException e)
-		{
-			return getURLValid2(url); //Retries with old uri builder
-		}
-	}
-
-	private String getURLValid2(String url) {
-		HTTPClient.URI uri;
-		try
-		{
-			uri = new HTTPClient.URI(url);
-			setPrevURLhost(getHost());
-			setPrevURLbaseURL(getBaseURL());
-			setPrevURLport(getPort());
-			setPrevURLsecure(getSecure());
-			setIsURL(true);
-
-			setHost(uri.getHost());
-			setPort(uri.getPort());
-			setBaseURL(uri.getPath());
-			setSecure(uri.getScheme().equalsIgnoreCase("https") ? 1 : 0);
-
-			StringBuilder relativeUri = new StringBuilder();
-			if (uri.getPath() != null) {
-				relativeUri.append(uri.getPath());
-			}
-			if (uri.getQueryString() != null) {
-				relativeUri.append('?').append(uri.getQueryString());
-			}
-			if (uri.getFragment() != null) {
-				relativeUri.append('#').append(uri.getFragment());
-			}
-			return relativeUri.toString();
-		}
-		catch (ParseException e)
 		{
 			return url;
 		}

--- a/java/src/test/java/com/genexus/internet/TestHttpClient.java
+++ b/java/src/test/java/com/genexus/internet/TestHttpClient.java
@@ -1,0 +1,52 @@
+package com.genexus.internet;
+import com.genexus.Application;
+import com.genexus.sampleapp.GXcfg;
+import com.genexus.specific.java.Connect;
+import com.genexus.specific.java.LogManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestHttpClient {
+
+	private static String TEST_URL_ERROR = "https://localhost/My API with Spaces";
+	private static String TEST_URL_OK = "https://www.google.com/";
+	@Before
+	public void setUp() throws Exception {
+		Connect.init();
+		Application.init(GXcfg.class);
+		LogManager.initialize(".");
+	}
+
+	@Test
+	public void executeHttpGetJavaLibInvalidURI() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", TEST_URL_ERROR);
+		Assert.assertEquals(0, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaOldLibInvalidURI() {
+		HttpClientManual httpClient = new HttpClientManual();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", TEST_URL_ERROR);
+		Assert.assertEquals(0, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaLib() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", TEST_URL_OK);
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaOldLib() {
+		HttpClientManual httpClient = new HttpClientManual();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", TEST_URL_OK);
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+}

--- a/java/src/test/java/com/genexus/internet/TestHttpClient.java
+++ b/java/src/test/java/com/genexus/internet/TestHttpClient.java
@@ -9,9 +9,6 @@ import org.junit.Test;
 
 public class TestHttpClient {
 
-	private static String TEST_URL_ERROR = "https://localhost/My API with Spaces";
-	private static String TEST_URL_OK = "https://www.google.com/";
-	private static String TEST_URL_OK_WITH_SPACES = "https://www.google.com?q=My API with Spaces";
 	@Before
 	public void setUp() throws Exception {
 		Connect.init();
@@ -23,15 +20,7 @@ public class TestHttpClient {
 	public void executeHttpGetJavaLibInvalidURI() {
 		HttpClientJavaLib httpClient = new HttpClientJavaLib();
 		httpClient.setTimeout(1);
-		httpClient.execute("GET", TEST_URL_ERROR);
-		Assert.assertEquals(0, httpClient.getStatusCode());
-	}
-
-	@Test
-	public void executeHttpGetJavaOldLibInvalidURI() {
-		HttpClientManual httpClient = new HttpClientManual();
-		httpClient.setTimeout(1);
-		httpClient.execute("GET", TEST_URL_ERROR);
+		httpClient.execute("GET", "https://localhost/My API with Spaces");
 		Assert.assertEquals(0, httpClient.getStatusCode());
 	}
 
@@ -39,15 +28,7 @@ public class TestHttpClient {
 	public void executeHttpGetJavaLib() {
 		HttpClientJavaLib httpClient = new HttpClientJavaLib();
 		httpClient.setTimeout(1);
-		httpClient.execute("GET", TEST_URL_OK);
-		Assert.assertEquals(200, httpClient.getStatusCode());
-	}
-
-	@Test
-	public void executeHttpGetJavaOldLib() {
-		HttpClientManual httpClient = new HttpClientManual();
-		httpClient.setTimeout(1);
-		httpClient.execute("GET", TEST_URL_OK);
+		httpClient.execute("GET", "https://www.google.com/");
 		Assert.assertEquals(200, httpClient.getStatusCode());
 	}
 
@@ -55,15 +36,16 @@ public class TestHttpClient {
 	public void executeHttpGetJavaLib2() {
 		HttpClientJavaLib httpClient = new HttpClientJavaLib();
 		httpClient.setTimeout(1);
-		httpClient.execute("GET", TEST_URL_OK_WITH_SPACES);
+		httpClient.execute("GET", "https://www.google.com?q=My API with Spaces");
 		Assert.assertEquals(200, httpClient.getStatusCode());
 	}
 
 	@Test
-	public void executeHttpGetJavaOldLib2() {
-		HttpClientManual httpClient = new HttpClientManual();
+	public void executeHttpGetJavaLib3() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
 		httpClient.setTimeout(1);
-		httpClient.execute("GET", TEST_URL_OK_WITH_SPACES);
-		Assert.assertEquals(200, httpClient.getStatusCode());
+		httpClient.execute("GET", "https://www.google.com/test api");
+		Assert.assertEquals(404, httpClient.getStatusCode());
 	}
+
 }

--- a/java/src/test/java/com/genexus/internet/TestHttpClient.java
+++ b/java/src/test/java/com/genexus/internet/TestHttpClient.java
@@ -11,6 +11,7 @@ public class TestHttpClient {
 
 	private static String TEST_URL_ERROR = "https://localhost/My API with Spaces";
 	private static String TEST_URL_OK = "https://www.google.com/";
+	private static String TEST_URL_OK_WITH_SPACES = "https://www.google.com?q=My API with Spaces";
 	@Before
 	public void setUp() throws Exception {
 		Connect.init();
@@ -47,6 +48,22 @@ public class TestHttpClient {
 		HttpClientManual httpClient = new HttpClientManual();
 		httpClient.setTimeout(1);
 		httpClient.execute("GET", TEST_URL_OK);
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaLib2() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", TEST_URL_OK_WITH_SPACES);
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaOldLib2() {
+		HttpClientManual httpClient = new HttpClientManual();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", TEST_URL_OK_WITH_SPACES);
 		Assert.assertEquals(200, httpClient.getStatusCode());
 	}
 }

--- a/java/src/test/java/com/genexus/internet/TestHttpClient.java
+++ b/java/src/test/java/com/genexus/internet/TestHttpClient.java
@@ -48,4 +48,11 @@ public class TestHttpClient {
 		Assert.assertEquals(404, httpClient.getStatusCode());
 	}
 
+	@Test
+	public void executeHttpGetJavaLib4() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://www.google.com/test api?q=hello world");
+		Assert.assertEquals(404, httpClient.getStatusCode());
+	}
 }


### PR DESCRIPTION
This code:

`&HttpClient.Execute(!"GET", !"https://localhost/My API with spaces")`

Failed with the following Exception:
```
at java.base/java.net.URI$Parser.fail(URI.java:2915)
at java.base/java.net.URI$Parser.checkChars(URI.java:3086)
at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3168)
at java.base/java.net.URI$Parser.parse(URI.java:3116)
at java.base/java.net.URI.<init>(URI.java:600)
at java.base/java.net.URI.create(URI.java:881)
```

With the Previous HttpClient implementation, this code worked ok. (also works on .NET Environments), as Whitespaces were automatically encoded. 

- Added UnitTests

