### PR TITLE
Mtom was not being using never. It must be used if the service do not…

### DIFF
--- a/wrapperjakarta/src/main/java/com/genexus/ws/GXHandlerChain.java
+++ b/wrapperjakarta/src/main/java/com/genexus/ws/GXHandlerChain.java
@@ -27,13 +27,15 @@ public class GXHandlerChain implements SOAPHandler<SOAPMessageContext> {
         java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
         ;
         try {
-            messageContext.getMessage().writeTo(out);
-            String messageBody = new String(out.toByteArray(), "utf-8");
-            if (Boolean.FALSE.equals(outboundProperty)) {
-                messageContext.put(GX_SOAP_BODY, messageBody);
-                messageContext.setScope(GX_SOAP_BODY, MessageContext.Scope.APPLICATION);
-            }
-            logger.debug(messageBody);
+			if (logger.isDebugEnabled()) {
+				messageContext.getMessage().writeTo(out);
+				String messageBody = new String(out.toByteArray(), "utf-8");
+				if (Boolean.FALSE.equals(outboundProperty)) {
+					messageContext.put(GX_SOAP_BODY, messageBody);
+					messageContext.setScope(GX_SOAP_BODY, MessageContext.Scope.APPLICATION);
+				}
+				logger.debug(messageBody);
+			}
         } catch (Exception e) {
             logger.error("Exception in handler: ", e);
         }

--- a/wrapperjakarta/src/main/java/com/genexus/ws/GXHandlerConsumerChain.java
+++ b/wrapperjakarta/src/main/java/com/genexus/ws/GXHandlerConsumerChain.java
@@ -53,19 +53,37 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 		return headers;
 	}
 
+	private SOAPMessage message;
+	private SOAPEnvelope envelope;
+	private SOAPHeader header;
+
+	private void getMessageData(SOAPMessageContext messageContext)
+	{
+		if (message == null)
+		{
+			message = messageContext.getMessage();
+			try
+			{
+				envelope = message.getSOAPPart().getEnvelope();
+				header = envelope.getHeader();
+			}
+			catch (SOAPException e)
+			{
+				logger.error("Exception in getMessageData: ", e);
+			}
+		}
+	}
+
 	public boolean handleMessage(SOAPMessageContext messageContext)
 	{
 		Boolean outboundProperty = (Boolean) messageContext.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
-		java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();;
+		java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
 		try
 		{
-			SOAPMessage message = messageContext.getMessage();
-			SOAPEnvelope envelope = message.getSOAPPart().getEnvelope();
-			SOAPHeader header = envelope.getHeader();
-
 			//soapHeadersRaw
 			if (Boolean.TRUE.equals(outboundProperty) && soapHeaderRaw != null)
 			{
+				getMessageData(messageContext);
 				Document doc = parseXML(soapHeaderRaw);
 				header.detachNode();
 				SOAPHeader sh = envelope.addHeader();
@@ -78,6 +96,7 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 			IGXWSAddressing wsAddressing = location.getWSAddressing();
 			if (wsAddressing != null && Boolean.TRUE.equals(outboundProperty) && soapHeaderRaw == null && !wsAddressing.getMessageID().isEmpty())
 			{
+				getMessageData(messageContext);
 				header.addNamespaceDeclaration("wsa", WSSECURITY_ADDRESSING_URL);
 
 				//wsa:Action
@@ -133,6 +152,7 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 
 			if (Boolean.TRUE.equals(outboundProperty) && soapHeaderRaw == null && ((wsSignature != null && !wsSignature.getAlias().isEmpty()) || (wsEncryption != null && !wsEncryption.getAlias().isEmpty())))
 			{
+				getMessageData(messageContext);
 				Document doc = messageToDocument(messageContext.getMessage());
 
 				//Security header
@@ -192,9 +212,11 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 				message.saveChanges();
 			}
 
-			messageContext.getMessage().writeTo(out);
-			String messageBody = new String(out.toByteArray(), "utf-8");
-			logger.debug(messageBody);
+			if (logger.isDebugEnabled()) {
+				messageContext.getMessage().writeTo(out);
+				String messageBody = new String(out.toByteArray(), "utf-8");
+				logger.debug(messageBody);
+			}
 		}
 		catch (Exception e)
 		{

--- a/wrapperjavax/src/main/java/com/genexus/ws/GXHandlerChain.java
+++ b/wrapperjavax/src/main/java/com/genexus/ws/GXHandlerChain.java
@@ -27,13 +27,15 @@ public class GXHandlerChain implements SOAPHandler<SOAPMessageContext> {
         java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
         ;
         try {
-            messageContext.getMessage().writeTo(out);
-            String messageBody = new String(out.toByteArray(), "utf-8");
-            if (Boolean.FALSE.equals(outboundProperty)) {
-                messageContext.put(GX_SOAP_BODY, messageBody);
-                messageContext.setScope(GX_SOAP_BODY, MessageContext.Scope.APPLICATION);
-            }
-            logger.debug(messageBody);
+			if (logger.isDebugEnabled()) {
+				messageContext.getMessage().writeTo(out);
+				String messageBody = new String(out.toByteArray(), "utf-8");
+				if (Boolean.FALSE.equals(outboundProperty)) {
+					messageContext.put(GX_SOAP_BODY, messageBody);
+					messageContext.setScope(GX_SOAP_BODY, MessageContext.Scope.APPLICATION);
+				}
+				logger.debug(messageBody);
+			}
         } catch (Exception e) {
             logger.error("Exception in handler: ", e);
         }

--- a/wrapperjavax/src/main/java/com/genexus/ws/GXHandlerConsumerChain.java
+++ b/wrapperjavax/src/main/java/com/genexus/ws/GXHandlerConsumerChain.java
@@ -53,19 +53,37 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 		return headers;
 	}
 
+	private SOAPMessage message;
+	private SOAPEnvelope envelope;
+	private SOAPHeader header;
+
+	private void getMessageData(SOAPMessageContext messageContext)
+	{
+		if (message == null)
+		{
+			message = messageContext.getMessage();
+			try
+			{
+				envelope = message.getSOAPPart().getEnvelope();
+				header = envelope.getHeader();
+			}
+			catch (SOAPException e)
+			{
+				logger.error("Exception in getMessageData: ", e);
+			}
+		}
+	}
+
 	public boolean handleMessage(SOAPMessageContext messageContext)
 	{
 		Boolean outboundProperty = (Boolean) messageContext.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
-		java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();;
+		java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
 		try
 		{
-			SOAPMessage message = messageContext.getMessage();
-			SOAPEnvelope envelope = message.getSOAPPart().getEnvelope();
-			SOAPHeader header = envelope.getHeader();
-
 			//soapHeadersRaw
 			if (Boolean.TRUE.equals(outboundProperty) && soapHeaderRaw != null)
 			{
+				getMessageData(messageContext);
 				Document doc = parseXML(soapHeaderRaw);
 				header.detachNode();
 				SOAPHeader sh = envelope.addHeader();
@@ -78,6 +96,7 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 			IGXWSAddressing wsAddressing = location.getWSAddressing();
 			if (wsAddressing != null && Boolean.TRUE.equals(outboundProperty) && soapHeaderRaw == null && !wsAddressing.getMessageID().isEmpty())
 			{
+				getMessageData(messageContext);
 				header.addNamespaceDeclaration("wsa", WSSECURITY_ADDRESSING_URL);
 
 				//wsa:Action
@@ -133,6 +152,7 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 
 			if (Boolean.TRUE.equals(outboundProperty) && soapHeaderRaw == null && ((wsSignature != null && !wsSignature.getAlias().isEmpty()) || (wsEncryption != null && !wsEncryption.getAlias().isEmpty())))
 			{
+				getMessageData(messageContext);
 				Document doc = messageToDocument(messageContext.getMessage());
 
 				//Security header
@@ -192,9 +212,11 @@ public class GXHandlerConsumerChain implements SOAPHandler<SOAPMessageContext>
 				message.saveChanges();
 			}
 
-			messageContext.getMessage().writeTo(out);
-			String messageBody = new String(out.toByteArray(), "utf-8");
-			logger.debug(messageBody);
+			if (logger.isDebugEnabled()) {
+				messageContext.getMessage().writeTo(out);
+				String messageBody = new String(out.toByteArray(), "utf-8");
+				logger.debug(messageBody);
+			}
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
… have ws-security and logging is off

When messageContext.getMessage() is invoked Mtom is disabled, so we must invoke it only in the cases when we need it (to configure ws-security or print request and response log)
Issue: 100558