### PR TITLE
HttpClient.Execute() crashes when the URL contains White spaces

### DIFF
--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -3222,7 +3222,7 @@ public final class CommonUtil
 			{
 				try
 				{
-					String encoded = URLEncoder.encode( Character.toString(ch), "UTF-8" );
+					String encoded = URLEncoder.encode( Character.toString(ch), "UTF-8" ).replaceAll("\\+", "%20");
 					for (int i = 0; i < encoded.length(); i++)
 						buf[dst++] = encoded.charAt(i);
 				}

--- a/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
+++ b/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
@@ -188,37 +188,42 @@ public class HttpClientJavaLib extends GXHttpClient {
 	}
 
 	private String getURLValid(String url) {
-		URI uri;
 		try
 		{
-			uri = new URI(url);
-			if (!uri.isAbsolute())		// En caso que la URL pasada por parametro no sea una URL valida (en este caso seria que no sea un URL absoluta), salta una excepcion en esta linea, y se continua haciendo todo el proceso con los datos ya guardados como atributos
-				return url;
-			else {
-				setPrevURLhost(getHost());
-				setPrevURLbaseURL(getBaseURL());
-				setPrevURLport(getPort());
-				setPrevURLsecure(getSecure());
-				setIsURL(true);
-				setURL(url);
-
-				StringBuilder relativeUri = new StringBuilder();
-				if (uri.getPath() != null) {
-					relativeUri.append(uri.getPath());
-				}
-				if (uri.getQuery() != null) {
-					relativeUri.append('?').append(uri.getQuery());
-				}
-				if (uri.getFragment() != null) {
-					relativeUri.append('#').append(uri.getFragment());
-				}
-				return relativeUri.toString();
+			URI uri;
+			try {
+				uri = new URI(url);
 			}
+			catch (URISyntaxException _) {
+				url = CommonUtil.escapeUnsafeChars(url);
+				uri = new URI(url);
+			}
+			if (!uri.isAbsolute()) {        // En caso que la URL pasada por parametro no sea una URL valida (en este caso seria que no sea un URL absoluta), salta una excepcion en esta linea, y se continua haciendo todo el proceso con los datos ya guardados como atributos
+				return url;
+			}
+			setPrevURLhost(getHost());
+			setPrevURLbaseURL(getBaseURL());
+			setPrevURLport(getPort());
+			setPrevURLsecure(getSecure());
+			setIsURL(true);
+			setURL(url);
+
+			StringBuilder relativeUri = new StringBuilder();
+			if (uri.getRawPath() != null) {
+				relativeUri.append(uri.getRawPath());
+			}
+			if (uri.getRawQuery() != null) {
+				relativeUri.append('?').append(uri.getRawQuery());
+			}
+			if (uri.getRawFragment() != null) {
+				relativeUri.append('#').append(uri.getRawFragment());
+			}
+			return relativeUri.toString();
 		}
-		catch (URISyntaxException e)
+		catch (URISyntaxException _)
 		{
-			return url;
 		}
+		return url;
 	}
 
 	private static SSLConnectionSocketFactory getSSLSecureInstance() {

--- a/java/src/test/java/com/genexus/internet/TestHttpClient.java
+++ b/java/src/test/java/com/genexus/internet/TestHttpClient.java
@@ -1,0 +1,100 @@
+package com.genexus.internet;
+import com.genexus.Application;
+import com.genexus.CommonUtil;
+import com.genexus.sampleapp.GXcfg;
+import com.genexus.specific.java.Connect;
+import com.genexus.specific.java.LogManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestHttpClient {
+
+	@Before
+	public void setUp() throws Exception {
+		Connect.init();
+		Application.init(GXcfg.class);
+		LogManager.initialize(".");
+	}
+
+	@Test
+	public void executeHttpGetJavaLibInvalidURI() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://localhost/My API with Spaces");
+		Assert.assertEquals(0, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaLib() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://www.google.com/");
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaLib2() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://www.google.com?q=My API with Spaces");
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaLib3() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://www.google.com/test api");
+		Assert.assertEquals(404, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaLib4() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://www.google.com/test api?q=hello world");
+		Assert.assertEquals(404, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void executeHttpGetJavaLib5() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://www.google.com:80/test api?q=hello world");
+		Assert.assertEquals(404, httpClient.getStatusCode());
+	}
+	@Test
+	public void executeHttpGetJavaLib6() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://www.google.com:80");
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+
+
+	@Test
+	public void executeHttpGetJavaLibWithAccent() {
+		HttpClientJavaLib httpClient = new HttpClientJavaLib();
+		httpClient.setTimeout(1);
+		httpClient.execute("GET", "https://maps.googleapis.com/maps/api/geocode/json?address=Dirección");
+		Assert.assertEquals(200, httpClient.getStatusCode());
+	}
+
+	@Test
+	public void escapeUrlTest1() {
+		String rawUrl = "https://maps.googleapis.com/maps/api/geocode/json?address=Dirección";
+		String escapedSafeUrl = CommonUtil.escapeUnsafeChars(rawUrl);
+		String expectedUrl = "https://maps.googleapis.com/maps/api/geocode/json?address=Direcci%C3%B3n";
+		Assert.assertEquals(expectedUrl, escapedSafeUrl);
+	}
+
+	@Test
+	public void escapeUrlTest2() {
+		String rawUrl = "https://www.google.com:80?q=My API with Spaces";
+		String escapedSafeUrl = CommonUtil.escapeUnsafeChars(rawUrl);
+		String expectedUrl = "https://www.google.com:80?q=My%20API%20with%20Spaces";
+		Assert.assertEquals(expectedUrl, escapedSafeUrl);
+	}
+
+}


### PR DESCRIPTION
This code:

&HttpClient.Execute(!"GET", !"https://localhost/My API with spaces")

Failed with the following Exception:

```
at java.base/java.net.URI$Parser.fail(URI.java:2915)
at java.base/java.net.URI$Parser.checkChars(URI.java:3086)
at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3168)
at java.base/java.net.URI$Parser.parse(URI.java:3116)
at java.base/java.net.URI.<init>(URI.java:600)
at java.base/java.net.URI.create(URI.java:881)
```

With the Previous HttpClient implementation, this code worked ok. (also works on .NET Environments), as Whitespaces were automatically encoded by the Framework. 

- Added UnitTests