### PR TITLE
Bump jackson libraries to version 2.14.1

### DIFF
--- a/gxawsserverless/pom.xml
+++ b/gxawsserverless/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-            <version>2.13.2.1</version>
+           	<version>${jackson.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.spy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <jersey.jakarta.version>3.0.4</jersey.jakarta.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <poi.version>5.2.2</poi.version>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <junit.version>4.13.2</junit.version>
         <com.amazonaws.version>1.12.93</com.amazonaws.version>
         <software.awssdk.version>2.17.272</software.awssdk.version>


### PR DESCRIPTION
Issue:99255
Update jackson libraries to the last released version 2.14.1
CVE-2022-42003
CVE-2022-42004
#GXSEC