### PR TITLE
Bump commons-net to version 3.9.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>commons-net</groupId>
 			<artifactId>commons-net</artifactId>
-			<version>3.3</version>
+			<version>3.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.transaction</groupId>


### PR DESCRIPTION
Issue:100443
Update commons-net to version 3.9.0
CVE-2021-37533
#GXSEC