### PR TITLE
Added webp-imageio lib as dependency to support webp

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -163,6 +163,11 @@
             <artifactId>opentelemetry-api</artifactId>
             <version>${io.opentelemetry.version}</version>
         </dependency>
+        <dependency>
+    		<groupId>com.github.usefulness</groupId>
+    		<artifactId>webp-imageio</artifactId>
+    		<version>0.2.1</version>
+		</dependency>
     </dependencies>
 	
 	<build>


### PR DESCRIPTION
Issue 101090

https://github.com/usefulness/webp-imageio provides Java with Image I/O reader and writer for the Google WebP image format. It is added as a dependency of the _java_ project
