### PR TITLE
Revert "Added webp-imageio lib as dependency to support webp (#657)"

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -163,11 +163,6 @@
             <artifactId>opentelemetry-api</artifactId>
             <version>${io.opentelemetry.version}</version>
         </dependency>
-        <dependency>
-    		<groupId>com.github.usefulness</groupId>
-    		<artifactId>webp-imageio</artifactId>
-    		<version>0.2.1</version>
-		</dependency>
     </dependencies>
 	
 	<build>


### PR DESCRIPTION
This reverts commit 2beb566d81e146eb04a3c1e8ee29b981fd4057db born from Issue 101090.