### PR TITLE
Exclude azure-keyvault-core dependency from Azure Blob Storage

### DIFF
--- a/gxcloudstorage-azureblob/pom.xml
+++ b/gxcloudstorage-azureblob/pom.xml
@@ -28,6 +28,12 @@
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>azure-storage</artifactId>
 			<version>8.6.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-keyvault-core</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Exclude "azure-keyvault-core" as the generated GeneXus program does not use it at all