### PR TITLE
Fix Javadocs error when deploying

### DIFF
--- a/java/src/main/java/com/genexus/reports/PDFReportItext.java
+++ b/java/src/main/java/com/genexus/reports/PDFReportItext.java
@@ -217,7 +217,7 @@ public class PDFReportItext implements IReportHandler
      * utiliza esta property para obtener la ubicación + ejecutable del Acrobat, sino se busca en el Registry
      * @param pdfFilename Nombre del reporte a imprimir (con extensión)
      * @param silent Booleano que indica si se va a imprimir sin diálogo
-     * @exception Excepcion si no se puede realizar la operación
+     * @exception Exception si no se puede realizar la operación
      */
     public static void printReport(String pdfFilename, boolean silent) throws Exception
     {
@@ -251,7 +251,7 @@ public class PDFReportItext implements IReportHandler
     /** Muestra el reporte en pantalla
      * @param filename nombre del PDF a mostrar
      * @param modal indica si el PDF se va a mostrar en diálogo modal
-     * @exception Si no se puede encontrar el Acrobat
+     * @exception Exception no se puede encontrar el Acrobat
      */
     public static void showReport(String filename, boolean modal) throws Exception
     {


### PR DESCRIPTION
```
Error:  MavenReportException: Error while generating Javadoc: 
Exit code: 1 - /home/runner/work/JavaClasses/JavaClasses/androidreports/src/main/java/com/genexus/reports/PDFReportItext.java:249: error: reference not found
     * @exception exception si no se puede encontrar el Acrobat
       ^
```