### PR TITLE
GXNavigationHelper Exception when using Http Redis WebSession. 

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -669,7 +669,16 @@ public abstract class HttpContext
 	
 	protected GXNavigationHelper getNavigationHelper(boolean useWebSession)
 	{
-		GXNavigationHelper helper = (GXNavigationHelper)getSessionValue(GX_NAV_HELPER);
+		GXNavigationHelper helper;
+		try
+		{
+			helper = (GXNavigationHelper) getSessionValue(GX_NAV_HELPER);
+		}
+		catch (Exception e)
+		{
+			//If it gives an error to recover the GXNavigationHelper from the session then I start with a new GXNavigationHelper to avoid a runtime error
+			helper = null;
+		}
 		if (helper == null)
 		{
 			helper = new GXNavigationHelper();


### PR DESCRIPTION
Sometimes when a webapplications reload and Redis is used to save web sessions a cast exception is throwed when GXNavigationHelper is retrived and it have a diferente classloader.

This is the error throwed:
[com.genexus.servlet.ServletException: com.genexus.servlet.ServletException: com.genexus.servlet.ServletException: com.genexus.servlet.ServletException: java.lang.ClassCastException: class com.genexus.internet.GXNavigationHelper cannot be cast to class com.genexus.internet.GXNavigationHelper (com.genexus.internet.GXNavigationHelper is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @20888aa8; com.genexus.internet.GXNavigationHelper is in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @63854e64)

Error can not be reproduced so a catch is implemented to avoid a runtime error Issue: 101399