### PR TITLE
GxclassR pom must not declare bouncy castle dependency because it is …

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -147,12 +147,6 @@
             <artifactId>opentelemetry-api</artifactId>
             <version>${io.opentelemetry.version}</version>
         </dependency>
-		<dependency>
-		    <groupId>org.bouncycastle</groupId>
-		    <artifactId>bcprov-jdk15on</artifactId>
-		    <version>1.69</version>
-		</dependency>
-        
     </dependencies>
 	
 	<build>


### PR DESCRIPTION
…already declared in common module pom

Issue: 101506