### PR TITLE
Serverless EventResponse:  Handled Member renamed to HandleFailure

### DIFF
--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/GXProcedureExecutor.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/GXProcedureExecutor.java
@@ -80,7 +80,6 @@ public class GXProcedureExecutor {
 				break;
 			case 2:
 				parameters = new Object[]{rawJsonEvent};
-				response.setHandled(true);
 				returnsValue = false;
 				break;
 			case 3:
@@ -89,7 +88,6 @@ public class GXProcedureExecutor {
 			default:
 				parameters = new Object[]{};
 				returnsValue = false;
-				response.setHandled(true);
 				break;
 		}
 

--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/handler/LambdaBaseEventHandler.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/handler/LambdaBaseEventHandler.java
@@ -80,7 +80,7 @@ public class LambdaBaseEventHandler {
 			throw e;
 		}
 
-		if (!response.isHandled()) {
+		if (response.hasFailed()) {
 			logger.info("dispatchEventmessages - messages not handled with success: " + response.getErrorMessage());
 		} else {
 			logger.debug("dispatchEventmessages - message handled with success");

--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/handler/LambdaEventBridgeHandler.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/handler/LambdaEventBridgeHandler.java
@@ -58,7 +58,7 @@ public class LambdaEventBridgeHandler extends LambdaBaseEventHandler implements 
 			return "";
 		}
 
-		if (!response.isHandled()) {
+		if (response.hasFailed()) {
 			//Throw exception in order to mark the message as not processed.
 			logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
 			throw new RuntimeException(response.getErrorMessage());

--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/handler/LambdaSQSHandler.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/aws/handler/LambdaSQSHandler.java
@@ -65,7 +65,7 @@ public class LambdaSQSHandler extends LambdaBaseEventHandler implements RequestH
 
 		try {
 			EventMessageResponse response = dispatchEvent(msgs, Helper.toJSONString(sqsEvent));
-			wasHandled = response.isHandled();
+			wasHandled = !response.hasFailed();
 			errorMessage = response.getErrorMessage();
 		} catch (Exception e) {
 			errorMessage = "HandleRequest execution error";

--- a/gxawsserverless/src/main/java/com/genexus/cloud/serverless/model/EventMessageResponse.java
+++ b/gxawsserverless/src/main/java/com/genexus/cloud/serverless/model/EventMessageResponse.java
@@ -3,18 +3,18 @@ package com.genexus.cloud.serverless.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class EventMessageResponse {
-	@JsonProperty("Handled")
-	private boolean handled = false;
+	@JsonProperty("HandleFailure")
+	private boolean hasFailed = false;
 
 	@JsonProperty("ErrorMessage")
 	private String errorMessage = "";
 
-	public boolean isHandled() {
-		return handled;
+	public boolean hasFailed() {
+		return hasFailed;
 	}
 
-	public void setHandled(boolean handled) {
-		this.handled = handled;
+	public void setAsFailed(boolean hasFailed) {
+		this.hasFailed = hasFailed;
 	}
 
 	public String getErrorMessage() {

--- a/gxawsserverless/src/test/java/com/genexus/cloud/aws/events/TestLambdaEventBridgeHandler.java
+++ b/gxawsserverless/src/test/java/com/genexus/cloud/aws/events/TestLambdaEventBridgeHandler.java
@@ -30,21 +30,21 @@ public class TestLambdaEventBridgeHandler {
 	public void simpleEvent() throws Exception {
 		LambdaEventBridgeHandler handler = new LambdaEventBridgeHandler(SIMPLE_HANDLER);
 		String result = handler.handleRequest(createEvent(), new MockContext());
-		Assert.assertEquals("{\"Handled\":true,\"ErrorMessage\":\"\"}", result);
+		Assert.assertEquals("{\"HandleFailure\":false,\"ErrorMessage\":\"\"}", result);
 	}
 
 	@Test
 	public void simpleEventRaw() throws Exception {
 		LambdaEventBridgeHandler handler = new LambdaEventBridgeHandler(SIMPLE_RAW_HANDLER);
 		String result = handler.handleRequest(createEvent(), new MockContext());
-		Assert.assertEquals("{\"Handled\":true,\"ErrorMessage\":\"\"}", result);
+		Assert.assertEquals("{\"HandleFailure\":false,\"ErrorMessage\":\"\"}", result);
 	}
 
 	@Test
 	public void simpleEventNoParms() throws Exception {
 		LambdaEventBridgeHandler handler = new LambdaEventBridgeHandler(handlesimplenoparmsevent.class.getName());
 		String result = handler.handleRequest(createEvent(), new MockContext());
-		Assert.assertEquals("{\"Handled\":true,\"ErrorMessage\":\"\"}", result);
+		Assert.assertEquals("{\"HandleFailure\":false,\"ErrorMessage\":\"\"}", result);
 	}
 
 

--- a/gxawsserverless/src/test/java/com/genexus/genexusserverlessapi/SdtEventMessageResponse.java
+++ b/gxawsserverless/src/test/java/com/genexus/genexusserverlessapi/SdtEventMessageResponse.java
@@ -1,111 +1,224 @@
-package com.genexus.genexusserverlessapi;
-
+package com.genexus.genexusserverlessapi ;
 import com.genexus.*;
 import com.genexus.*;
 import com.genexus.xml.*;
 import com.genexus.search.*;
 import com.genexus.webpanels.*;
-
 import java.util.*;
 
-public final class SdtEventMessageResponse extends GxUserType {
-	public SdtEventMessageResponse() {
-		this(new ModelContext(SdtEventMessageResponse.class));
-	}
+public final  class SdtEventMessageResponse extends GxUserType
+{
+   public SdtEventMessageResponse( )
+   {
+      this(  new ModelContext(SdtEventMessageResponse.class));
+   }
 
-	public SdtEventMessageResponse(ModelContext context) {
-		super(context, "SdtEventMessageResponse");
-	}
+   public SdtEventMessageResponse( ModelContext context )
+   {
+      super( context, "SdtEventMessageResponse");
+   }
 
-	public SdtEventMessageResponse(int remoteHandle,
-								   ModelContext context) {
-		super(remoteHandle, context, "SdtEventMessageResponse");
-	}
+   public SdtEventMessageResponse( int remoteHandle ,
+                                   ModelContext context )
+   {
+      super( remoteHandle, context, "SdtEventMessageResponse");
+   }
 
-	public SdtEventMessageResponse(StructSdtEventMessageResponse struct) {
-		this();
-		setStruct(struct);
-	}
+   public SdtEventMessageResponse( StructSdtEventMessageResponse struct )
+   {
+      this();
+      setStruct(struct);
+   }
 
-	private static java.util.HashMap mapper = new java.util.HashMap();
+   private static java.util.HashMap mapper = new java.util.HashMap();
+   static
+   {
+   }
 
-	static {
-	}
+   public String getJsonMap( String value )
+   {
+      return (String) mapper.get(value);
+   }
 
-	public String getJsonMap(String value) {
-		return (String) mapper.get(value);
-	}
+   public short readxml( com.genexus.xml.XMLReader oReader ,
+                         String sName )
+   {
+      short GXSoapError = 1;
+      formatError = false ;
+      sTagName = oReader.getName() ;
+      if ( oReader.getIsSimple() == 0 )
+      {
+         GXSoapError = oReader.read() ;
+         nOutParmCount = (short)(0) ;
+         while ( ( ( GXutil.strcmp(oReader.getName(), sTagName) != 0 ) || ( oReader.getNodeType() == 1 ) ) && ( GXSoapError > 0 ) )
+         {
+            readOk = (short)(0) ;
+            readElement = false ;
+            if ( GXutil.strcmp2( oReader.getLocalName(), "HandleFailure") )
+            {
+               gxTv_SdtEventMessageResponse_Handlefailure = (boolean)((((GXutil.strcmp(oReader.getValue(), "true")==0)||(GXutil.strcmp(oReader.getValue(), "1")==0) ? 1 : 0)==0)?false:true) ;
+               readElement = true ;
+               if ( GXSoapError > 0 )
+               {
+                  readOk = (short)(1) ;
+               }
+               GXSoapError = oReader.read() ;
+            }
+            if ( GXutil.strcmp2( oReader.getLocalName(), "ErrorMessage") )
+            {
+               gxTv_SdtEventMessageResponse_Errormessage = oReader.getValue() ;
+               readElement = true ;
+               if ( GXSoapError > 0 )
+               {
+                  readOk = (short)(1) ;
+               }
+               GXSoapError = oReader.read() ;
+            }
+            if ( ! readElement )
+            {
+               readOk = (short)(1) ;
+               GXSoapError = oReader.read() ;
+            }
+            nOutParmCount = (short)(nOutParmCount+1) ;
+            if ( ( readOk == 0 ) || formatError )
+            {
+               context.globals.sSOAPErrMsg += "Error reading " + sTagName + GXutil.newLine( ) ;
+               context.globals.sSOAPErrMsg += "Message: " + oReader.readRawXML() ;
+               GXSoapError = (short)(nOutParmCount*-1) ;
+            }
+         }
+      }
+      return GXSoapError ;
+   }
 
-	public void tojson() {
-		tojson(true);
-	}
+   public void writexml( com.genexus.xml.XMLWriter oWriter ,
+                         String sName ,
+                         String sNameSpace )
+   {
+      writexml(oWriter, sName, sNameSpace, true);
+   }
 
-	public void tojson(boolean includeState) {
-		tojson(includeState, true);
-	}
+   public void writexml( com.genexus.xml.XMLWriter oWriter ,
+                         String sName ,
+                         String sNameSpace ,
+                         boolean sIncludeState )
+   {
+      if ( (GXutil.strcmp("", sName)==0) )
+      {
+         sName = "EventMessageResponse" ;
+      }
+      if ( (GXutil.strcmp("", sNameSpace)==0) )
+      {
+         sNameSpace = "ServerlessAPI" ;
+      }
+      oWriter.writeStartElement(sName);
+      if ( GXutil.strcmp(GXutil.left( sNameSpace, 10), "[*:nosend]") != 0 )
+      {
+         oWriter.writeAttribute("xmlns", sNameSpace);
+      }
+      else
+      {
+         sNameSpace = GXutil.right( sNameSpace, GXutil.len( sNameSpace)-10) ;
+      }
+      oWriter.writeElement("HandleFailure", GXutil.booltostr( gxTv_SdtEventMessageResponse_Handlefailure));
+      if ( GXutil.strcmp(sNameSpace, "ServerlessAPI") != 0 )
+      {
+         oWriter.writeAttribute("xmlns", "ServerlessAPI");
+      }
+      oWriter.writeElement("ErrorMessage", gxTv_SdtEventMessageResponse_Errormessage);
+      if ( GXutil.strcmp(sNameSpace, "ServerlessAPI") != 0 )
+      {
+         oWriter.writeAttribute("xmlns", "ServerlessAPI");
+      }
+      oWriter.writeEndElement();
+   }
 
-	public void tojson(boolean includeState,
-					   boolean includeNonInitialized) {
-		AddObjectProperty("Handled", gxTv_SdtEventMessageResponse_Handled, false, false);
-		AddObjectProperty("ErrorMessage", gxTv_SdtEventMessageResponse_Errormessage, false, false);
-	}
+   public void tojson( )
+   {
+      tojson( true) ;
+   }
 
-	public boolean getgxTv_SdtEventMessageResponse_Handled() {
-		return gxTv_SdtEventMessageResponse_Handled;
-	}
+   public void tojson( boolean includeState )
+   {
+      tojson( includeState, true) ;
+   }
 
-	public void setgxTv_SdtEventMessageResponse_Handled(boolean value) {
-		gxTv_SdtEventMessageResponse_N = (byte) (0);
-		gxTv_SdtEventMessageResponse_Handled = value;
-	}
+   public void tojson( boolean includeState ,
+                       boolean includeNonInitialized )
+   {
+      AddObjectProperty("HandleFailure", gxTv_SdtEventMessageResponse_Handlefailure, false, false);
+      AddObjectProperty("ErrorMessage", gxTv_SdtEventMessageResponse_Errormessage, false, false);
+   }
 
-	public String getgxTv_SdtEventMessageResponse_Errormessage() {
-		return gxTv_SdtEventMessageResponse_Errormessage;
-	}
+   public boolean getgxTv_SdtEventMessageResponse_Handlefailure( )
+   {
+      return gxTv_SdtEventMessageResponse_Handlefailure ;
+   }
 
-	public void setgxTv_SdtEventMessageResponse_Errormessage(String value) {
-		gxTv_SdtEventMessageResponse_N = (byte) (0);
-		gxTv_SdtEventMessageResponse_Errormessage = value;
-	}
+   public void setgxTv_SdtEventMessageResponse_Handlefailure( boolean value )
+   {
+      gxTv_SdtEventMessageResponse_N = (byte)(0) ;
+      gxTv_SdtEventMessageResponse_Handlefailure = value ;
+   }
 
-	public void initialize(int remoteHandle) {
-		initialize();
-	}
+   public String getgxTv_SdtEventMessageResponse_Errormessage( )
+   {
+      return gxTv_SdtEventMessageResponse_Errormessage ;
+   }
 
-	public void initialize() {
-		gxTv_SdtEventMessageResponse_N = (byte) (1);
-		gxTv_SdtEventMessageResponse_Errormessage = "";
-		sTagName = "";
-	}
+   public void setgxTv_SdtEventMessageResponse_Errormessage( String value )
+   {
+      gxTv_SdtEventMessageResponse_N = (byte)(0) ;
+      gxTv_SdtEventMessageResponse_Errormessage = value ;
+   }
 
-	public byte isNull() {
-		return gxTv_SdtEventMessageResponse_N;
-	}
+   public void initialize( int remoteHandle )
+   {
+      initialize( ) ;
+   }
 
-	public com.genexus.genexusserverlessapi.SdtEventMessageResponse Clone() {
-		return (com.genexus.genexusserverlessapi.SdtEventMessageResponse) (clone());
-	}
+   public void initialize( )
+   {
+      gxTv_SdtEventMessageResponse_N = (byte)(1) ;
+      gxTv_SdtEventMessageResponse_Errormessage = "" ;
+      sTagName = "" ;
+   }
 
-	public void setStruct(com.genexus.genexusserverlessapi.StructSdtEventMessageResponse struct) {
-		setgxTv_SdtEventMessageResponse_Handled(struct.getHandled());
-		setgxTv_SdtEventMessageResponse_Errormessage(struct.getErrormessage());
-	}
+   public byte isNull( )
+   {
+      return gxTv_SdtEventMessageResponse_N ;
+   }
 
-	@SuppressWarnings("unchecked")
-	public com.genexus.genexusserverlessapi.StructSdtEventMessageResponse getStruct() {
-		com.genexus.genexusserverlessapi.StructSdtEventMessageResponse struct = new com.genexus.genexusserverlessapi.StructSdtEventMessageResponse();
-		struct.setHandled(getgxTv_SdtEventMessageResponse_Handled());
-		struct.setErrormessage(getgxTv_SdtEventMessageResponse_Errormessage());
-		return struct;
-	}
+   public com.genexus.genexusserverlessapi.SdtEventMessageResponse Clone( )
+   {
+      return (com.genexus.genexusserverlessapi.SdtEventMessageResponse)(clone()) ;
+   }
 
-	protected byte gxTv_SdtEventMessageResponse_N;
-	protected short readOk;
-	protected short nOutParmCount;
-	protected String sTagName;
-	protected boolean gxTv_SdtEventMessageResponse_Handled;
-	protected boolean readElement;
-	protected boolean formatError;
-	protected String gxTv_SdtEventMessageResponse_Errormessage;
+   public void setStruct( com.genexus.genexusserverlessapi.StructSdtEventMessageResponse struct )
+   {
+      if ( struct != null )
+      {
+         setgxTv_SdtEventMessageResponse_Handlefailure(struct.getHandlefailure());
+         setgxTv_SdtEventMessageResponse_Errormessage(struct.getErrormessage());
+      }
+   }
+
+   @SuppressWarnings("unchecked")
+   public com.genexus.genexusserverlessapi.StructSdtEventMessageResponse getStruct( )
+   {
+      com.genexus.genexusserverlessapi.StructSdtEventMessageResponse struct = new com.genexus.genexusserverlessapi.StructSdtEventMessageResponse ();
+      struct.setHandlefailure(getgxTv_SdtEventMessageResponse_Handlefailure());
+      struct.setErrormessage(getgxTv_SdtEventMessageResponse_Errormessage());
+      return struct ;
+   }
+
+   protected byte gxTv_SdtEventMessageResponse_N ;
+   protected short readOk ;
+   protected short nOutParmCount ;
+   protected String sTagName ;
+   protected boolean gxTv_SdtEventMessageResponse_Handlefailure ;
+   protected boolean readElement ;
+   protected boolean formatError ;
+   protected String gxTv_SdtEventMessageResponse_Errormessage ;
 }
 

--- a/gxawsserverless/src/test/java/com/genexus/genexusserverlessapi/StructSdtEventMessageResponse.java
+++ b/gxawsserverless/src/test/java/com/genexus/genexusserverlessapi/StructSdtEventMessageResponse.java
@@ -1,47 +1,53 @@
-package com.genexus.genexusserverlessapi;
-
+package com.genexus.genexusserverlessapi ;
 import com.genexus.*;
 
-public final class StructSdtEventMessageResponse implements Cloneable, java.io.Serializable {
-	public StructSdtEventMessageResponse() {
-		this(-1, new ModelContext(StructSdtEventMessageResponse.class));
-	}
+public final  class StructSdtEventMessageResponse implements Cloneable, java.io.Serializable
+{
+   public StructSdtEventMessageResponse( )
+   {
+      this( -1, new ModelContext( StructSdtEventMessageResponse.class ));
+   }
 
-	public StructSdtEventMessageResponse(int remoteHandle,
-										 ModelContext context) {
-		gxTv_SdtEventMessageResponse_Errormessage = "";
-	}
+   public StructSdtEventMessageResponse( int remoteHandle ,
+                                         ModelContext context )
+   {
+      gxTv_SdtEventMessageResponse_Errormessage = "" ;
+   }
 
-	public Object clone() {
-		Object cloned = null;
-		try {
-			cloned = super.clone();
-		} catch (CloneNotSupportedException e) {
-			;
-		}
-		return cloned;
-	}
+   public Object clone()
+   {
+      Object cloned = null;
+      try
+      {
+         cloned = super.clone();
+      }catch (CloneNotSupportedException e){ ; }
+      return cloned;
+   }
 
-	public boolean getHandled() {
-		return gxTv_SdtEventMessageResponse_Handled;
-	}
+   public boolean getHandlefailure( )
+   {
+      return gxTv_SdtEventMessageResponse_Handlefailure ;
+   }
 
-	public void setHandled(boolean value) {
-		gxTv_SdtEventMessageResponse_N = (byte) (0);
-		gxTv_SdtEventMessageResponse_Handled = value;
-	}
+   public void setHandlefailure( boolean value )
+   {
+      gxTv_SdtEventMessageResponse_N = (byte)(0) ;
+      gxTv_SdtEventMessageResponse_Handlefailure = value ;
+   }
 
-	public String getErrormessage() {
-		return gxTv_SdtEventMessageResponse_Errormessage;
-	}
+   public String getErrormessage( )
+   {
+      return gxTv_SdtEventMessageResponse_Errormessage ;
+   }
 
-	public void setErrormessage(String value) {
-		gxTv_SdtEventMessageResponse_N = (byte) (0);
-		gxTv_SdtEventMessageResponse_Errormessage = value;
-	}
+   public void setErrormessage( String value )
+   {
+      gxTv_SdtEventMessageResponse_N = (byte)(0) ;
+      gxTv_SdtEventMessageResponse_Errormessage = value ;
+   }
 
-	protected byte gxTv_SdtEventMessageResponse_N;
-	protected boolean gxTv_SdtEventMessageResponse_Handled;
-	protected String gxTv_SdtEventMessageResponse_Errormessage;
+   protected byte gxTv_SdtEventMessageResponse_N ;
+   protected boolean gxTv_SdtEventMessageResponse_Handlefailure ;
+   protected String gxTv_SdtEventMessageResponse_Errormessage ;
 }
 

--- a/gxawsserverless/src/test/java/com/unittest/eventdriven/dummy/handlesimplesqsevent.java
+++ b/gxawsserverless/src/test/java/com/unittest/eventdriven/dummy/handlesimplesqsevent.java
@@ -29,7 +29,6 @@ public final class handlesimplesqsevent extends GXProcedure {
 	private void privateExecute() {
 		System.out.println("START EventBridge Event received");
 		System.out.println("END EventBridge Event received");
-		handlesimplesqsevent.this.AV9EventMessageResponse.setgxTv_SdtEventMessageResponse_Handled(true);
 		cleanup();
 	}
 

--- a/gxawsserverless/src/test/java/com/unittest/eventdriven/dummy/handlesimplesqsevent2.java
+++ b/gxawsserverless/src/test/java/com/unittest/eventdriven/dummy/handlesimplesqsevent2.java
@@ -40,7 +40,6 @@ public final class handlesimplesqsevent2 extends GXProcedure {
 	private void privateExecute() {
 		System.out.println("START EventBridge Event received");
 		System.out.println("END EventBridge Event received");
-		handlesimplesqsevent2.this.AV9EventMessageResponse.setgxTv_SdtEventMessageResponse_Handled(true);
 		cleanup();
 	}
 

--- a/gxawsserverless/src/test/java/com/unittest/eventdriven/queue/handlesimplesqsevent.java
+++ b/gxawsserverless/src/test/java/com/unittest/eventdriven/queue/handlesimplesqsevent.java
@@ -30,7 +30,7 @@ public final class handlesimplesqsevent extends GXProcedure {
 		System.out.println(AV13RAWMessage);
 		System.out.println("END Queue Event received");
 		System.out.println((boolean) ((GXutil.len(AV13RAWMessage) > 0)));
-		AV9EventMessageResponse.setgxTv_SdtEventMessageResponse_Handled(AV13RAWMessage.startsWith("{\"records\":[{\"messageId\":\"1\",\"receiptHandle\":\"123123\",\"body\":\""));
+		AV9EventMessageResponse.setgxTv_SdtEventMessageResponse_Handlefailure(!AV13RAWMessage.startsWith("{\"records\":[{\"messageId\":\"1\",\"receiptHandle\":\"123123\",\"body\":\""));
 		cleanup();
 	}
 

--- a/gxawsserverless/src/test/java/com/unittest/eventdriven/queue/handlesimplesqsevent2.java
+++ b/gxawsserverless/src/test/java/com/unittest/eventdriven/queue/handlesimplesqsevent2.java
@@ -42,8 +42,8 @@ public final class handlesimplesqsevent2 extends GXProcedure {
 		while (AV16GXV1 <= AV8EventMessages.getgxTv_SdtEventMessages_Eventmessage().size()) {
 			AV10EventMessage = (com.genexus.genexusserverlessapi.SdtEventMessage) ((com.genexus.genexusserverlessapi.SdtEventMessage) AV8EventMessages.getgxTv_SdtEventMessages_Eventmessage().elementAt(-1 + AV16GXV1));
 			System.out.println("Processing: " + AV10EventMessage.toJSonString(false, true));
-			AV9EventMessageResponse.setgxTv_SdtEventMessageResponse_Handled(AV11UserSDT.fromJSonString(AV10EventMessage.getgxTv_SdtEventMessage_Eventmessagedata(), AV12OutMessages));
-			if (!AV9EventMessageResponse.getgxTv_SdtEventMessageResponse_Handled()) {
+			AV9EventMessageResponse.setgxTv_SdtEventMessageResponse_Handlefailure(!AV11UserSDT.fromJSonString(AV10EventMessage.getgxTv_SdtEventMessage_Eventmessagedata(), AV12OutMessages));
+			if (AV9EventMessageResponse.getgxTv_SdtEventMessageResponse_Handlefailure()) {
 				System.out.println("EventMessageData could not be parsed: " + AV10EventMessage.getgxTv_SdtEventMessage_Eventmessagedata());
 				System.out.println(AV12OutMessages.toJSonString(false));
 				AV9EventMessageResponse.setgxTv_SdtEventMessageResponse_Errormessage(AV12OutMessages.toJSonString(false));


### PR DESCRIPTION
Now by default, all Event Driven messages are considered to be handled successfully. 

Handled renamed to HandleFailure. 

Issue: 101505