### PR TITLE
Fix Timezone Crash when Timezone does not exist

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.10.4</version>
+			<version>2.12.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-net</groupId>

--- a/java/src/main/java/com/genexus/specific/java/GXutil.java
+++ b/java/src/main/java/com/genexus/specific/java/GXutil.java
@@ -18,7 +18,6 @@ import org.apache.commons.io.IOUtils;
 
 import com.genexus.Application;
 import com.genexus.PrivateUtilities;
-import com.genexus.ModelContext;
 import com.genexus.common.interfaces.IExtensionGXutil;
 import com.genexus.db.IDataStoreProvider;
 import com.genexus.util.CacheAPI;
@@ -33,12 +32,11 @@ public class GXutil implements IExtensionGXutil {
 		DateTimeZone jodaTZ = DateTimeZone.getDefault();
 		try {
 			jodaTZ = DateTimeZone.forID(tz.getID());
-		} catch (IllegalArgumentException e) {
+		} catch (IllegalArgumentException _) {
 			try {
 				jodaTZ = DateTimeZone.forTimeZone(tz);
-			}
 			} catch (IllegalArgumentException e) {
-				logger.error("Failed to find TimeZone: " + tz.getID(), e);
+				logger.error(String.format("Failed to find TimeZone: %s. Using default Timezone", tz.getID()), e);
 			}
 		}
 		return jodaTZ;

--- a/java/src/main/java/com/genexus/specific/java/GXutil.java
+++ b/java/src/main/java/com/genexus/specific/java/GXutil.java
@@ -22,16 +22,24 @@ import com.genexus.ModelContext;
 import com.genexus.common.interfaces.IExtensionGXutil;
 import com.genexus.db.IDataStoreProvider;
 import com.genexus.util.CacheAPI;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.joda.time.DateTimeZone;
 
 public class GXutil implements IExtensionGXutil {
+	private static Logger logger = LogManager.getLogger(GXutil.class);
 
-	private static org.joda.time.DateTimeZone Java2JodaTimeZone(TimeZone tz) {
-		org.joda.time.DateTimeZone jodaTZ;
+	private static DateTimeZone Java2JodaTimeZone(TimeZone tz) {
+		DateTimeZone jodaTZ = DateTimeZone.getDefault();
 		try {
-			jodaTZ = org.joda.time.DateTimeZone.forID(tz.getID());
+			jodaTZ = DateTimeZone.forID(tz.getID());
 		} catch (IllegalArgumentException e) {
-			jodaTZ = org.joda.time.DateTimeZone.forTimeZone(tz);
+			try {
+				jodaTZ = DateTimeZone.forTimeZone(tz);
+			}
+			} catch (IllegalArgumentException e) {
+				logger.error("Failed to find TimeZone: " + tz.getID(), e);
+			}
 		}
 		return jodaTZ;
 	}

--- a/java/src/test/java/com/genexus/util/TestDateMethods.java
+++ b/java/src/test/java/com/genexus/util/TestDateMethods.java
@@ -1,99 +1,130 @@
 package com.genexus.util;
 
-import com.genexus.Application;
 import com.genexus.CommonUtil;
 import com.genexus.LocalUtil;
+import com.genexus.specific.java.Connect;
+import org.junit.Assert;
+import org.junit.Test;
 
+import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import com.genexus.specific.java.Connect;
-import org.junit.Assert;
-import org.junit.Test;
-
 public class TestDateMethods {
 
-	@Test
-	public void testYearLimit(){
-		Connect.init();
-		LocalUtil localUtil = new LocalUtil('.', "MDY", "24", 30, "eng");
-		Date testDate1 = CommonUtil.nullDate();
-		Date testDate2 = CommonUtil.nullDate();
+    @Test
+    public void testYearLimit() {
+        Connect.init();
+        LocalUtil localUtil = new LocalUtil('.', "MDY", "24", 30, "eng");
+        Date testDate1 = CommonUtil.nullDate();
+        Date testDate2 = CommonUtil.nullDate();
 
-		String pattern = "dd/MM/yy";
+        String pattern = "dd/MM/yy";
 
-		GXSimpleDateFormat df = new GXSimpleDateFormat(pattern);
-		df.setTimeZone(TimeZone.getDefault());
-		try
-		{
-			testDate1 = localUtil.applyYearLimit(df.parse("12/12/30"), pattern);
-			testDate2 = localUtil.applyYearLimit(df.parse("08/05/76"), pattern);
-		}
-		catch (ParseException e)
-		{
+        GXSimpleDateFormat df = new GXSimpleDateFormat(pattern);
+        df.setTimeZone(TimeZone.getDefault());
+        try {
+            testDate1 = localUtil.applyYearLimit(df.parse("12/12/30"), pattern);
+            testDate2 = localUtil.applyYearLimit(df.parse("08/05/76"), pattern);
+        } catch (ParseException e) {
 
-		}
-		Calendar calendar = GregorianCalendar.getInstance();
-		calendar.setTime(testDate1);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 1930);
-		calendar.setTime(testDate2);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 1976);
-	}
+        }
+        Calendar calendar = GregorianCalendar.getInstance();
+        calendar.setTime(testDate1);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 1930);
+        calendar.setTime(testDate2);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 1976);
+    }
 
-	@Test
-	public void testCtotex(){
-		Connect.init();
+    @Test
+    public void testCtotex() {
+        Connect.init();
 
-		LocalUtil localUtil = new LocalUtil('.', "MDY", "24", 30, "eng");
-		Date testDate1 = CommonUtil.nullDate();
-		Date testDate2 = CommonUtil.nullDate();
-		Date testDate3 = CommonUtil.nullDate();
-		try
-		{
-			testDate1 = localUtil.ctotex("1930-01-01T00:00", 0);
-			testDate2 = localUtil.ctotex("2023-01-01T00:00:00", 0);
-			testDate3 = localUtil.ctotex("2200-12-31T00:00:00.000", 0);
-		}
-		catch (Exception e)
-		{ }
+        LocalUtil localUtil = new LocalUtil('.', "MDY", "24", 30, "eng");
+        Date testDate1 = CommonUtil.nullDate();
+        Date testDate2 = CommonUtil.nullDate();
+        Date testDate3 = CommonUtil.nullDate();
+        try {
+            testDate1 = localUtil.ctotex("1930-01-01T00:00", 0);
+            testDate2 = localUtil.ctotex("2023-01-01T00:00:00", 0);
+            testDate3 = localUtil.ctotex("2200-12-31T00:00:00.000", 0);
+        } catch (Exception e) {
+        }
 
-		Calendar calendar = GregorianCalendar.getInstance();
-		calendar.setTime(testDate1);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 1930);
-		calendar.setTime(testDate2);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 2023);
-		calendar.setTime(testDate3);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 2200);
+        Calendar calendar = GregorianCalendar.getInstance();
+        calendar.setTime(testDate1);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 1930);
+        calendar.setTime(testDate2);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 2023);
+        calendar.setTime(testDate3);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 2200);
 
-		testDate1 = CommonUtil.nullDate();
-		testDate2 = CommonUtil.nullDate();
-		testDate3 = CommonUtil.nullDate();
-		try
-		{
-			testDate1 = localUtil.ctotex("29-01-01", 0);
-			testDate2 = localUtil.ctotex("30-01-01T00", 0);
-			testDate3 = localUtil.ctotex("31-12-31T00:00", 0);
-		}
-		catch (Exception e)
-		{ }
+        testDate1 = CommonUtil.nullDate();
+        testDate2 = CommonUtil.nullDate();
+        testDate3 = CommonUtil.nullDate();
+        try {
+            testDate1 = localUtil.ctotex("29-01-01", 0);
+            testDate2 = localUtil.ctotex("30-01-01T00", 0);
+            testDate3 = localUtil.ctotex("31-12-31T00:00", 0);
+        } catch (Exception e) {
+        }
 
-		calendar = GregorianCalendar.getInstance();
-		calendar.setTime(testDate1);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 2029);
-		calendar.setTime(testDate2);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 1930);
-		calendar.setTime(testDate3);
-		Assert.assertTrue(calendar.get(Calendar.YEAR) == 1931);
-	}
+        calendar = GregorianCalendar.getInstance();
+        calendar.setTime(testDate1);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 2029);
+        calendar.setTime(testDate2);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 1930);
+        calendar.setTime(testDate3);
+        Assert.assertTrue(calendar.get(Calendar.YEAR) == 1931);
+    }
 
-	@Test
-	public void testTimeZone(){
-		Connect.init();
+    @Test
+    public void testValidTimezone() {
+        Connect.init();
+
+        String dateTime = "2023-03-22 15:00:00"; // input DateTime
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
 		TimeZone timezone = TimeZone.getTimeZone("America/Montevideo");
-		Date = com.genexus.specific.java.GXutil.DateTimeToUTC(new Date(), timezone);
-	}
+
+        try {
+            Date mvdDate = dateFormat.parse(dateTime); // convert String to Date
+			Date utcDate = CommonUtil.DateTimeToUTC(mvdDate, timezone);
+
+            long diff = utcDate.getTime() - mvdDate.getTime();
+            long expectedDiff = 10800000;
+            Assert.assertEquals("Timezone offset invalid", expectedDiff, diff);
+            System.out.println("");
+        } catch (Exception e) {
+			Assert.fail();
+        }
+    }
+
+    /**
+     * DateTimeToUTC must not fail if the Timezone does not exists.
+     */
+    @Test
+    public void testInvalidTimezone() {
+        Connect.init();
+
+        String dateTime = "2023-03-22 15:00:00"; // input DateTime
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        TimeZone timezone = TimeZone.getTimeZone("America/DoesnotExists");
+
+        try {
+            Date mvdDate = dateFormat.parse(dateTime); // convert String to Date
+            Date utcDate = CommonUtil.DateTimeToUTC(mvdDate, timezone);
+
+            long diff = utcDate.getTime() - mvdDate.getTime();
+            long expectedDiff = 0;
+            Assert.assertEquals("Timezone offset invalid", expectedDiff, diff);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
 }

--- a/java/src/test/java/com/genexus/util/TestDateMethods.java
+++ b/java/src/test/java/com/genexus/util/TestDateMethods.java
@@ -88,4 +88,12 @@ public class TestDateMethods {
 		calendar.setTime(testDate3);
 		Assert.assertTrue(calendar.get(Calendar.YEAR) == 1931);
 	}
+
+	@Test
+	public void testTimeZone(){
+		Connect.init();
+
+		TimeZone timezone = TimeZone.getTimeZone("America/Montevideo");
+		Date = com.genexus.specific.java.GXutil.DateTimeToUTC(new Date(), timezone);
+	}
 }

--- a/java/src/test/java/com/genexus/util/TestDateMethods.java
+++ b/java/src/test/java/com/genexus/util/TestDateMethods.java
@@ -98,7 +98,6 @@ public class TestDateMethods {
             long diff = utcDate.getTime() - mvdDate.getTime();
             long expectedDiff = 10800000;
             Assert.assertEquals("Timezone offset invalid", expectedDiff, diff);
-            System.out.println("");
         } catch (Exception e) {
 			Assert.fail();
         }


### PR DESCRIPTION
Fix crash: 

```
The datetime zone id 'America/Ciudad_Juarez' is not recognised
org.joda.time.DateTimeZone.forTimeZone (DateTimeZone.java:398)
com.genexus.specific.java.GXutil.Java2JodaTimeZone (GXutil.java:34)
com.genexus.specific.java.GXutil.DateTimeFromUTC (GXutil.java:51)
com.genexus.CommonUtil.DateTimeFromUTC (CommonUtil.java:937)
com.genexus.CommonUtil.ConvertDateTime (CommonUtil.java:910)
```

- Bump joda timezone maven library
- Do not crash Application when Timezone does not exists. Use default one. 
- Add UnitTests