### PR TITLE
Bump simple-xml-2.7.1 to simple-xml-safe

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,18 +33,18 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>
-		</dependency>		
-		<dependency>
-			<groupId>org.simpleframework</groupId>
-			<artifactId>simple-xml</artifactId>
-			<version>2.7.1</version>
-			<exclusions>
-				<exclusion>
-					<groupId>*</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-    	</exclusions>			
 		</dependency>
+        <dependency>
+            <groupId>com.carrotsearch.thirdparty</groupId>
+            <artifactId>simple-xml-safe</artifactId>
+            <version>2.7.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>


### PR DESCRIPTION
Issue:101670
Bump library simple-xml-2.7.1 to simple-xml.safe-2.7.1.
CVE-2017-1000190
#GXSEC