### PR TITLE
Remove joda time dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,11 +70,6 @@
 			<version>2.11.0</version>
 		</dependency>
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.12.2</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-net</groupId>
 			<artifactId>commons-net</artifactId>
 			<version>3.9.0</version>

--- a/java/src/test/java/com/genexus/util/TestDateMethods.java
+++ b/java/src/test/java/com/genexus/util/TestDateMethods.java
@@ -83,25 +83,34 @@ public class TestDateMethods {
     }
 
     @Test
-    public void testValidTimezone() {
+    public void testDateTimeToUTC() {
         Connect.init();
 
-        String dateTime = "2023-03-22 15:00:00"; // input DateTime
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		TimeZone timezone = TimeZone.getTimeZone("America/New_York");
 
-		TimeZone timezone = TimeZone.getTimeZone("America/Montevideo");
+        String dateTime = "2023-02-22 15:00:00"; // input DateTime
+		long expectedDiff = 18000000;
+		ConvertDateTime(dateTime, timezone, expectedDiff, true);
 
-        try {
-            Date mvdDate = dateFormat.parse(dateTime); // convert String to Date
-			Date utcDate = CommonUtil.DateTimeToUTC(mvdDate, timezone);
-
-            long diff = utcDate.getTime() - mvdDate.getTime();
-            long expectedDiff = 10800000;
-            Assert.assertEquals("Timezone offset invalid", expectedDiff, diff);
-        } catch (Exception e) {
-			Assert.fail();
-        }
+		dateTime = "2023-07-22 15:00:00"; // input DateTime during summer time
+		expectedDiff = 14400000;
+		ConvertDateTime(dateTime, timezone, expectedDiff, true);
     }
+
+	@Test
+	public void DateTimeFromUTC() {
+		Connect.init();
+
+		TimeZone timezone = TimeZone.getTimeZone("America/New_York");
+
+		String dateTime = "2023-02-22 20:00:00"; // input DateTime
+		long expectedDiff = -18000000;
+		ConvertDateTime(dateTime, timezone, expectedDiff, false);
+
+		dateTime = "2023-07-22 19:00:00"; // input DateTime during summer time
+		expectedDiff = -14400000;
+		ConvertDateTime(dateTime, timezone, expectedDiff, false);
+	}
 
     /**
      * DateTimeToUTC must not fail if the Timezone does not exists.
@@ -110,20 +119,29 @@ public class TestDateMethods {
     public void testInvalidTimezone() {
         Connect.init();
 
+		TimeZone timezone = TimeZone.getTimeZone("America/DoesnotExists");
+
         String dateTime = "2023-03-22 15:00:00"; // input DateTime
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
-        TimeZone timezone = TimeZone.getTimeZone("America/DoesnotExists");
-
-        try {
-            Date mvdDate = dateFormat.parse(dateTime); // convert String to Date
-            Date utcDate = CommonUtil.DateTimeToUTC(mvdDate, timezone);
-
-            long diff = utcDate.getTime() - mvdDate.getTime();
-            long expectedDiff = 0;
-            Assert.assertEquals("Timezone offset invalid", expectedDiff, diff);
-        } catch (Exception e) {
-            Assert.fail();
-        }
+		long expectedDiff = 0;
+		ConvertDateTime(dateTime, timezone, expectedDiff, true);
+		ConvertDateTime(dateTime, timezone, expectedDiff, false);
     }
+
+	private void ConvertDateTime(String dateTime, TimeZone timezone, long expectedDiff, boolean toUTC) {
+		DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		try {
+			Date mvdDate = dateFormat.parse(dateTime); // convert String to Date
+			Date dateConverted;
+			if (toUTC)
+				dateConverted = CommonUtil.DateTimeToUTC(mvdDate, timezone);
+			else
+				dateConverted = CommonUtil.DateTimeFromUTC(mvdDate, timezone);
+
+			long diff = dateConverted.getTime() - mvdDate.getTime();
+			Assert.assertEquals("Timezone offset invalid", expectedDiff, diff);
+		} catch (Exception e) {
+			Assert.fail();
+		}
+	}
+
 }


### PR DESCRIPTION
In order to convert dates to UTC dates and UTC dates to dates, remove joda time dependency and use JDK 8 ZonedDateTime data type. Issue:102003