### PR TITLE
Fix paging statements with SqlServer 2005 when the statement uses aliases

### DIFF
--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -2722,7 +2722,7 @@ public final class CommonUtil
 			pagingSelect = pagingSelect.substring(9);
 		pagingSelect = pagingSelect.replaceAll("T\\d+\\.", "GX_ICTE.");
 		if(PAGING_SELECT_PATTERN == null)
-			PAGING_SELECT_PATTERN = Pattern.compile("GX_ICTE\\.(\\[\\w+\\]) AS \\b(\\w+)\\b");
+			PAGING_SELECT_PATTERN = Pattern.compile("GX_ICTE\\.(\\[\\w+]) AS \\b(\\w+)\\b");
 		Matcher match = PAGING_SELECT_PATTERN.matcher(pagingSelect);
 		HashMap<String, String> maps = new HashMap<>();
 		while(match.find())

--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -2722,7 +2722,7 @@ public final class CommonUtil
 			pagingSelect = pagingSelect.substring(9);
 		pagingSelect = pagingSelect.replaceAll("T\\d+\\.", "GX_ICTE.");
 		if(pagingSelectPattern == null)
-			pagingSelectPattern = Pattern.compile("GX_ICTE\\.(\\[\\w+]) AS \\b(\\w+)\\b");
+			pagingSelectPattern = Pattern.compile("GX_ICTE\\.(\\[\\w+]) AS \\b(\\w+)\\b(?=,|$)");
 		Matcher match = pagingSelectPattern.matcher(pagingSelect);
 		HashMap<String, String> maps = new HashMap<>();
 		while(match.find())

--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -2714,16 +2714,16 @@ public final class CommonUtil
 	}
 
 
-	private static Pattern pagingSelectPattern;
+	private static Pattern PAGING_SELECT_PATTERN;
 	public static String pagingSelect(String select)
 	{
 		String pagingSelect = ltrim(select);
 		if(pagingSelect.startsWith("DISTINCT"))
 			pagingSelect = pagingSelect.substring(9);
 		pagingSelect = pagingSelect.replaceAll("T\\d+\\.", "GX_ICTE.");
-		if(pagingSelectPattern == null)
-			pagingSelectPattern = Pattern.compile("GX_ICTE\\.(\\[\\w+\\]) AS \\b(\\w+)\\b");
-		Matcher match = pagingSelectPattern.matcher(pagingSelect);
+		if(PAGING_SELECT_PATTERN == null)
+			PAGING_SELECT_PATTERN = Pattern.compile("GX_ICTE\\.(\\[\\w+\\]) AS \\b(\\w+)\\b");
+		Matcher match = PAGING_SELECT_PATTERN.matcher(pagingSelect);
 		HashMap<String, String> maps = new HashMap<>();
 		while(match.find())
 		{

--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -19,6 +19,8 @@ import java.security.*;
 import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.genexus.common.interfaces.SpecificImplementation;
 
@@ -2712,14 +2714,27 @@ public final class CommonUtil
 	}
 
 
+	private static Pattern pagingSelectPattern;
 	public static String pagingSelect(String select)
 	{
 		String pagingSelect = ltrim(select);
-		// Quita distinct
 		if(pagingSelect.startsWith("DISTINCT"))
 			pagingSelect = pagingSelect.substring(9);
-		// Renombra referencias a tablas por GXICTE
 		pagingSelect = pagingSelect.replaceAll("T\\d+\\.", "GX_ICTE.");
+		if(pagingSelectPattern == null)
+			pagingSelectPattern = Pattern.compile("GX_ICTE\\.(\\[\\w+\\]) AS \\b(\\w+)\\b");
+		Matcher match = pagingSelectPattern.matcher(pagingSelect);
+		HashMap<String, String> maps = new HashMap<>();
+		while(match.find())
+		{
+			if(match.groupCount() == 2)
+			{
+				maps.put(match.group(0), String.format("GX_ICTE.[%s]", match.group(2)));
+				maps.put(match.group(1), String.format("[%s]", match.group(2)));
+			}
+		}
+		for(Map.Entry<String, String> map : maps.entrySet())
+			pagingSelect = pagingSelect.replace(map.getKey(), map.getValue());
 		return pagingSelect;
 	}
 

--- a/common/src/main/java/com/genexus/CommonUtil.java
+++ b/common/src/main/java/com/genexus/CommonUtil.java
@@ -2714,16 +2714,16 @@ public final class CommonUtil
 	}
 
 
-	private static Pattern PAGING_SELECT_PATTERN;
+	private static Pattern pagingSelectPattern;
 	public static String pagingSelect(String select)
 	{
 		String pagingSelect = ltrim(select);
 		if(pagingSelect.startsWith("DISTINCT"))
 			pagingSelect = pagingSelect.substring(9);
 		pagingSelect = pagingSelect.replaceAll("T\\d+\\.", "GX_ICTE.");
-		if(PAGING_SELECT_PATTERN == null)
-			PAGING_SELECT_PATTERN = Pattern.compile("GX_ICTE\\.(\\[\\w+]) AS \\b(\\w+)\\b");
-		Matcher match = PAGING_SELECT_PATTERN.matcher(pagingSelect);
+		if(pagingSelectPattern == null)
+			pagingSelectPattern = Pattern.compile("GX_ICTE\\.(\\[\\w+]) AS \\b(\\w+)\\b");
+		Matcher match = pagingSelectPattern.matcher(pagingSelect);
 		HashMap<String, String> maps = new HashMap<>();
 		while(match.find())
 		{


### PR DESCRIPTION
Some paging statements generated for SQLServer 2005-2008 require an external subselect which is qualified with table name GX_ICTE. When the inner select uses aliases for some attribute (for example when using subtypes) the outer select must qualify them with GX_ICTE table and the alias used.
This code applies the alias mapping to the outer select.
Issue 71081