### PR TITLE
Fix broken reading of XML files

### DIFF
--- a/common/src/main/java/com/genexus/xml/XMLReader.java
+++ b/common/src/main/java/com/genexus/xml/XMLReader.java
@@ -884,9 +884,8 @@ public class XMLReader implements XMLDocumentHandler, XMLErrorHandler, XMLDTDHan
 						is.close();
 					}
 				}
-				if (inputSource.getByteStream() != null) inputSource.getByteStream().close();
 			}
-			parserConfiguration.cleanup();
+			if (parserConfiguration != null) parserConfiguration.cleanup();
         }
         catch (IOException e) 
 		{
@@ -894,6 +893,11 @@ public class XMLReader implements XMLDocumentHandler, XMLErrorHandler, XMLDTDHan
 			errDescription = e.getMessage();
 	    }
 		inputSource = null;
+	}
+
+	@Override
+	protected void finalize() {
+		this.close();
 	}
 
 	public void addSchema(String url, String schema)

--- a/common/src/main/java/com/genexus/xml/XMLReader.java
+++ b/common/src/main/java/com/genexus/xml/XMLReader.java
@@ -785,9 +785,9 @@ public class XMLReader implements XMLDocumentHandler, XMLErrorHandler, XMLDTDHan
 	public void openResource(String url)
 	{
 		reset();
-		try (InputStream stream = ResourceReader.getFile(url);)
+		try
 		{
-
+			InputStream stream = ResourceReader.getFile(url);
 			if	(stream == null)
 			{
 				errCode = ERROR_IO;
@@ -833,8 +833,9 @@ public class XMLReader implements XMLDocumentHandler, XMLErrorHandler, XMLDTDHan
 	public void openResponse(com.genexus.internet.HttpClient client)
 	{
 		reset();
-		try (InputStream is = client.getInputStream())
+		try
 		{
+			InputStream is = client.getInputStream();
 			if (documentEncoding.length() > 0)
 				inputSource = new XMLInputSource(null, null, null, is, documentEncoding);
 			else
@@ -851,8 +852,9 @@ public class XMLReader implements XMLDocumentHandler, XMLErrorHandler, XMLDTDHan
 	public void openRequest(IHttpRequest client)
 	{
 		reset();
-		try (InputStream is = client.getInputStream())
+		try
 		{
+			InputStream is = client.getInputStream();
 			if (documentEncoding.length() > 0)
 				inputSource = new XMLInputSource(null, null, null, is, documentEncoding);
 			else
@@ -882,8 +884,9 @@ public class XMLReader implements XMLDocumentHandler, XMLErrorHandler, XMLDTDHan
 						is.close();
 					}
 				}
+				if (inputSource.getByteStream() != null) inputSource.getByteStream().close();
 			}
-			parserConfiguration.cleanup();			
+			parserConfiguration.cleanup();
         }
         catch (IOException e) 
 		{


### PR DESCRIPTION
Issue: 103796

This was broken because a couple of open input streams were closed using try-with resources meaning that the resource was closed as soon as the try block finished executing which meant that it was found closed when later needed by the class. The resource is now being closed in the close method of the class, when XML reading is over.