### PR TITLE
Bump jtidy library to version 1.0.4

### DIFF
--- a/gxsearch/pom.xml
+++ b/gxsearch/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 	    <groupId>com.github.jtidy</groupId>
 	    <artifactId>jtidy</artifactId>
-	    <version>1.0.3</version>
+	    <version>1.0.4</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Issue:103889

Bump jtidy library from version 1.0.3 to version 1.0.4

CVE-2023-34623

#GXSEC