### PR TITLE
Fix socket closed in Android. Revert changes from 745

### DIFF
--- a/common/src/main/java/HTTPClient/SocksClient.java
+++ b/common/src/main/java/HTTPClient/SocksClient.java
@@ -212,9 +212,15 @@ class SocksClient
 
 	    return sock;
 	}
-	finally
+	catch (IOException ioe)
 	{
-		if (sock != null) sock.close();
+		if (sock != null)
+		{
+			try { sock.close(); }
+			catch (IOException ee) {}
+		}
+
+		throw ioe;
 	}
     }
 


### PR DESCRIPTION
Problema:

Issue:
https://issues.genexus.com/viewissue.aspx?104236
Socket is closed al llamar httpclient a partir de offline

Solucion: 
Hacer revert de algunos de los cambios en el PR :
https://github.com/genexuslabs/JavaClasses/pull/745/

Cuando la funcion GetSocket o sendRequest es usada, no cerrar el socket que se utiliza, porque luego es consultado para ver los resultados del httpclient.

Nota: Seguramente hay que liberar el socket al destruir el httpclient o la conexion. Eso no lo toco ahora  para evitar otro broken.