### PR TITLE
Avoid execute savepoints sentences in PostgreSQL 

### DIFF
--- a/java/src/main/java/com/genexus/db/DataStoreProvider.java
+++ b/java/src/main/java/com/genexus/db/DataStoreProvider.java
@@ -438,7 +438,9 @@ public class DataStoreProvider extends DataStoreProviderBase implements
 	
 	private void executeSavePointOperation(String operation, Cursor cursor) 
 	{
-		if (getDataSource().dbms.getId() == GXDBMS.DBMS_POSTGRESQL && GXutil.dbmsVersion( context, remoteHandle, getDataSource().name) > 7 && cursor instanceof ForEachCursor && cursor.isCurrentOf())
+		if (getDataSource().dbms.getId() == GXDBMS.DBMS_POSTGRESQL && GXutil.dbmsVersion( context, remoteHandle, getDataSource().name) > 7
+			&& cursor instanceof ForEachCursor && cursor.isCurrentOf()
+			&& context.getPreferences().getProperty("GenerateSavePoints", "1").equals("1"))
 		{
 	    	try
 	    	{


### PR DESCRIPTION
when GENERATE_SAVEPOINT_SQL=N is set in config.gx

Issue: 104312