### PR TITLE
Support for disabling Buffered output response for realtime data streaming (SSE)

### DIFF
--- a/gxweb/src/main/java/com/genexus/webpanels/WebWrapper.java
+++ b/gxweb/src/main/java/com/genexus/webpanels/WebWrapper.java
@@ -40,7 +40,7 @@ public class WebWrapper
 			((HttpContext) context.getHttpContext()).setContext(context);
 			panel.httpContext = (HttpAjaxContext)context.getHttpContext();
 			panel.httpContext.setCompression(false);
-			panel.httpContext.setBuffered(false);
+			panel.httpContext.setResponseBufferMode(HttpContext.ResponseBufferMode.SERVER_DEFAULT);
 			panel.httpContext.useUtf8 = true;
 			panel.httpContext.setOutputStream(new java.io.ByteArrayOutputStream());
 		}

--- a/java/src/main/java/com/genexus/GXWebReport.java
+++ b/java/src/main/java/com/genexus/GXWebReport.java
@@ -33,7 +33,7 @@ public abstract class GXWebReport extends GXWebProcedure
 	{
 		super.initState(context, ui);
 
-		httpContext.setBuffered(true);
+		httpContext.setResponseBufferMode(HttpContext.ResponseBufferMode.ENABLED);
 		httpContext.setBinary(true);
 		String implementation = com.genexus.Application.getClientContext().getClientPreferences().getPDF_RPT_LIBRARY();
 		if (implementation.equals("ITEXT"))

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -613,10 +613,6 @@ public abstract class HttpContext implements IHttpContext
 
 	public void setResponseBufferMode(ResponseBufferMode bufferMode)
 	{
-		if (bufferMode == ResponseBufferMode.DISABLED) {
-		//	setCompression(false); //TODO: Check why we need to disable compression. This shouldn't be required
-		}
-
 		this.bufferMode = bufferMode;
 	}
 

--- a/java/src/main/java/com/genexus/internet/HttpContext.java
+++ b/java/src/main/java/com/genexus/internet/HttpContext.java
@@ -1,21 +1,22 @@
 package com.genexus.internet;
 
-import java.io.*;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Hashtable;
-
+import com.genexus.*;
+import com.genexus.servlet.http.ICookie;
+import com.genexus.servlet.http.IHttpServletRequest;
+import com.genexus.servlet.http.IHttpServletResponse;
+import com.genexus.webpanels.WebSession;
 import json.org.json.IJsonFormattable;
 import json.org.json.JSONArray;
 import json.org.json.JSONException;
 import json.org.json.JSONObject;
 import org.apache.logging.log4j.Logger;
 
-import com.genexus.*;
-import com.genexus.servlet.http.ICookie;
-import com.genexus.servlet.http.IHttpServletRequest;
-import com.genexus.servlet.http.IHttpServletResponse;
-import com.genexus.webpanels.WebSession;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Hashtable;
 
 public abstract class HttpContext implements IHttpContext
 {
@@ -89,11 +90,6 @@ public abstract class HttpContext implements IHttpContext
 	{
 		ignoreSpa = true;
 	}
-
-	public void setChunked()
-	{
-		isChunked = true;
-	}
 	
 	public boolean isSoapRequest()
 	{
@@ -114,7 +110,7 @@ public abstract class HttpContext implements IHttpContext
 	public com.genexus.xml.XMLWriter GX_xmlwrt = new com.genexus.xml.XMLWriter();
 
 	protected com.genexus.util.FastByteArrayOutputStream buffer;
-	protected boolean buffered;
+	protected ResponseBufferMode bufferMode = ResponseBufferMode.SERVER_DEFAULT;
 	protected boolean compressed;
 	protected boolean doNotCompress;
 	protected ModelContext context;
@@ -131,7 +127,6 @@ public abstract class HttpContext implements IHttpContext
 	protected boolean wrapped = false;
 	protected int drawGridsAtServer = -1;
 	private boolean ignoreSpa = false;
-	private boolean isChunked = false;
 
 	private static HashMap<String, Messages> cachedMessages = new HashMap<String, Messages>();
 	protected String currentLanguage = null;
@@ -180,7 +175,7 @@ public abstract class HttpContext implements IHttpContext
 		ctx.GX_msglist		=  GX_msglist;
 		ctx.GX_xmlwrt		=  GX_xmlwrt;
 		ctx.buffer			=  buffer;
-		ctx.buffered		=  buffered;
+		ctx.bufferMode		=  bufferMode;
 		ctx.compressed		=  compressed;
 		ctx.out				=  out;
 		ctx.writer			=  writer;
@@ -567,11 +562,22 @@ public abstract class HttpContext implements IHttpContext
 	}
 
 
-	public void writeBytes(byte[] bytes) throws IOException
-	{
-            out.write(bytes);
-			if (isChunked || getHttpResponse().getHeader("Transfer-Encoding").equalsIgnoreCase("chunked"))
-				out.flush();
+	public void writeBytes(byte[] bytes) throws IOException {
+		out.write(bytes);
+
+		if (bufferMode == ResponseBufferMode.DISABLED) {
+			tryFlushStream();
+		}
+	}
+
+	private void tryFlushStream() {
+		try {
+			out.flush();
+		}
+		catch (IOException e)
+		{
+			logger.debug("Failed to flush Http stream", e);
+		}
 	}
 
 	public OutputStream getOutputStream()
@@ -605,9 +611,13 @@ public abstract class HttpContext implements IHttpContext
 		}
 	}
 
-	public void setBuffered(boolean buffered)
+	public void setResponseBufferMode(ResponseBufferMode bufferMode)
 	{
-		this.buffered = buffered;
+		if (bufferMode == ResponseBufferMode.DISABLED) {
+		//	setCompression(false); //TODO: Check why we need to disable compression. This shouldn't be required
+		}
+
+		this.bufferMode = bufferMode;
 	}
 
 	public void setCompression(boolean compressed)
@@ -961,5 +971,11 @@ public abstract class HttpContext implements IHttpContext
 			((IGxJSONAble)SdtObj).FromJSONObject(jsonObj);
 		}
 		catch(JSONException exc) {}
+	}
+
+	public enum ResponseBufferMode {
+		DISABLED, // The response buffer is disabled and the server does not use any buffering.
+		SERVER_DEFAULT, // The server uses its default buffering behavior, which includes a buffer size. When the buffer is full, it flushes the response.
+		ENABLED // Not recommended: The response buffer is enabled and actively used by the server with a Custom GeneXus implementation.
 	}
 }

--- a/java/src/main/java/com/genexus/webpanels/GXWebProcedure.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebProcedure.java
@@ -69,16 +69,15 @@ public abstract class GXWebProcedure extends GXObjectBase
 		super.initState(context, ui);
 
 		if(httpContext.getHttpSecure() == 0)httpContext.setHeader("pragma", "no-cache");
-		if (isChunked()) {
-			httpContext.setChunked();
-			httpContext.setCompression(false);
-		}
 
+		if (!isBufferedResponse()) {
+			httpContext.setResponseBufferMode(HttpContext.ResponseBufferMode.DISABLED);
+		}
 		initialize();
 	}
 
-	protected boolean isChunked() {
-		return false;
+	protected boolean isBufferedResponse() {
+		return true;
 	}
 
 	protected void preExecute()

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -1389,7 +1389,7 @@ public class HttpContextWeb extends HttpContext {
 					String accepts = getHeader("Accept-Encoding");
 					if (accepts != null && accepts.indexOf("gzip") >= 0) {
 						setHeader("Content-Encoding", "gzip");
-						setOutputStream(new GZIPOutputStream(getOutputStream(), bufferMode == ResponseBufferMode.DISABLED));
+						setOutputStream(new GZIPOutputStream(getOutputStream(), true));
 					}
 				}
 			}

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -1378,7 +1378,7 @@ public class HttpContextWeb extends HttpContext {
 			if (mustUseWriter()) {
 				setWriter(getResponse().getWriter());
 			} else {
-				if (buffered) {
+				if (bufferMode == ResponseBufferMode.ENABLED) {
 					buffer = new com.genexus.util.FastByteArrayOutputStream();
 					setOutputStream(buffer);
 				} else {
@@ -1389,7 +1389,7 @@ public class HttpContextWeb extends HttpContext {
 					String accepts = getHeader("Accept-Encoding");
 					if (accepts != null && accepts.indexOf("gzip") >= 0) {
 						setHeader("Content-Encoding", "gzip");
-						setOutputStream(new GZIPOutputStream(getOutputStream()));
+						setOutputStream(new GZIPOutputStream(getOutputStream(), bufferMode == ResponseBufferMode.DISABLED));
 					}
 				}
 			}
@@ -1402,7 +1402,7 @@ public class HttpContextWeb extends HttpContext {
 		proxyCookieValues();
 
 		try {
-			if (buffered) {
+			if (bufferMode == ResponseBufferMode.ENABLED) {
 				// Esto en realidad cierra el ZipOutputStream, o el ByteOutputStream, no cierra
 				// el del
 				// servlet... Es necesario hacerlo, dado que sino el GZip no hace el flush de


### PR DESCRIPTION
- Add support for immediately responses (buffer disabled) through the http response
- Support no buffer responses with compression
- Automatically enable no buffer responses in SSE Responses

Issue: 104684