### PR TITLE
It's ok to encode the file name in Content-Disposition header, but it…

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/WebUtils.java
+++ b/java/src/main/java/com/genexus/webpanels/WebUtils.java
@@ -329,7 +329,7 @@ public class WebUtils
 		}
 		
 		String filename = value.substring(eqIdx + 1).trim();
-		value = value.substring(0, filenameIdx) + String.format("filename*=UTF-8''%1$s; filename=\"%1$s\"", PrivateUtilities.URLEncode(filename, "UTF8"));
+		value = value.substring(0, filenameIdx) + String.format("filename*=UTF-8''%1$s; filename=\"%1$s\"", PrivateUtilities.URLEncode(filename, "UTF8").replace('+', ' '));
 
 		return value;
 	}

--- a/java/src/test/java/com/genexus/webpanels/TestWebUtils.java
+++ b/java/src/test/java/com/genexus/webpanels/TestWebUtils.java
@@ -55,6 +55,12 @@ public class TestWebUtils {
 		doTest(contentDisposition, expectedContentDisposition);
 	}
 
+	@Test
+	public void TestContentDispositionHeaderEncoding7() {
+		String contentDisposition = "attachment; filename=My file.pdf";
+		String expectedContentDisposition = "attachment; filename*=UTF-8''My file.pdf; filename=\"My file.pdf\"";
+		doTest(contentDisposition, expectedContentDisposition);
+	}
 
 	private void doTest(String contentDisposition, String expectedContentDisposition) {
 		doTest(contentDisposition, expectedContentDisposition, HttpContextWeb.BROWSER_CHROME);


### PR DESCRIPTION
…'s not neccesary to encode blanks.

Issue: 105672