### PR TITLE
Use JMX support classes only when JMX is enabled to avoid unnecessary…

### DIFF
--- a/java/src/main/java/com/genexus/GXProcedure.java
+++ b/java/src/main/java/com/genexus/GXProcedure.java
@@ -37,9 +37,11 @@ public abstract class GXProcedure implements IErrorHandler, ISubmitteable {
 
 	public GXProcedure(boolean inNewUTL, int remoteHandle, ModelContext context, String location) {
 		//JMX Counter
-		beginExecute = new Date();
-		ProcedureInfo pInfo = ProceduresInfo.addProcedureInfo(this.getClass().getName());
-		pInfo.incCount();
+		if (Application.isJMXEnabled()) {
+			beginExecute = new Date();
+			ProcedureInfo pInfo = ProceduresInfo.addProcedureInfo(this.getClass().getName());
+			pInfo.incCount();
+		}
 
 		this.remoteHandle = remoteHandle;
 		this.context	  = context;
@@ -148,8 +150,10 @@ public abstract class GXProcedure implements IErrorHandler, ISubmitteable {
 	}
 
 	public void endExecute(String name) {
-		ProcedureInfo pInfo = ProceduresInfo.getProcedureInfo(name);
-		pInfo.setTimeExecute(System.currentTimeMillis() - beginExecute.getTime());
+		if (Application.isJMXEnabled()) {
+			ProcedureInfo pInfo = ProceduresInfo.getProcedureInfo(name);
+			pInfo.setTimeExecute(System.currentTimeMillis() - beginExecute.getTime());
+		}
 		
 		if (context != null && context.getSessionContext() != null) {
 			ApplicationContext.getInstance().setEJB(false);

--- a/java/src/main/java/com/genexus/db/DataStoreProvider.java
+++ b/java/src/main/java/com/genexus/db/DataStoreProvider.java
@@ -47,20 +47,17 @@ public class DataStoreProvider extends DataStoreProviderBase implements
 		super(context, remoteHandle);
 
 		//JMX Enabled
-		if (Application.isJMXEnabled())
-			if (firstTime.get())
-			{
+		if (Application.isJMXEnabled()) {
+			if (firstTime.get()) {
 				DataStoreProvidersJMX.CreateDataStoreProvidersJMX();
 				firstTime.set(false);
 			}
+			addDataStoreProviderInfo(helper.getClass().getName());
+		}
 
 		this.helper = helper;
 		this.cursors = helper.getCursors();
 		setOutputBuffers(buffers);
-
-		//JMX
-		addDataStoreProviderInfo(helper.getClass().getName());
-
 	}
 
         public void setErrorBuffers(int cursorIdx, Object[] buffers)
@@ -716,18 +713,20 @@ public class DataStoreProvider extends DataStoreProviderBase implements
 
 	void incSentencesCount(String key, Cursor cursor)
 	{
-
-		DataStoreProviderInfo dsInfo = getDataStoreProviderInfo(key);
-		dsInfo.incSentenceCount();
-		SentenceInfo sInfo;
-		if (cursor.dynStatement) {
-			sInfo = dsInfo.addSentenceInfo(key + "_" + cursor.mCursorId, key
+		DataStoreProviderInfo dsInfo = null;
+		if (Application.isJMXEnabled()) {
+			dsInfo = getDataStoreProviderInfo(key);
+			dsInfo.incSentenceCount();
+			SentenceInfo sInfo;
+			if (cursor.dynStatement) {
+				sInfo = dsInfo.addSentenceInfo(key + "_" + cursor.mCursorId, key
 					+ "_" + cursor.mCursorId + "_" + cursor.mSQLSentence);
-		} else {
-			sInfo = dsInfo.addSentenceInfo(key + "_" + cursor.mCursorId,
+			} else {
+				sInfo = dsInfo.addSentenceInfo(key + "_" + cursor.mCursorId,
 					cursor.mSQLSentence);
+			}
+			sInfo.incSentenceCount();
 		}
-		sInfo.incSentenceCount();
 
 		String sqlSnt = cursor.mSQLSentence;
 		sentenceCount.incrementAndGet();

--- a/java/src/main/java/com/genexus/performance/ProceduresInfo.java
+++ b/java/src/main/java/com/genexus/performance/ProceduresInfo.java
@@ -2,17 +2,13 @@ package com.genexus.performance;
 
 import java.io.PrintStream;
 import java.util.Enumeration;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.genexus.Application;
 
 public class ProceduresInfo
 {
-	static private Hashtable<String, ProcedureInfo> procedureInfo = new Hashtable<>();
-	
-  public ProceduresInfo()
-  {
-  }
+	static private ConcurrentHashMap<String, ProcedureInfo> procedureInfo = new ConcurrentHashMap<>();
   	
   static public void dump(PrintStream out)
   {


### PR DESCRIPTION
… proccess.

Change HashMap to ConcurrentHashMap in ProcedureInfo to allow concurrency when JMX is enabled Issue: 106110