### PR TITLE
FIx memory leak issue.

### DIFF
--- a/java/src/main/java/com/genexus/specific/java/GXSmartCacheProvider.java
+++ b/java/src/main/java/com/genexus/specific/java/GXSmartCacheProvider.java
@@ -152,10 +152,11 @@ public class GXSmartCacheProvider implements IExtensionGXSmartCacheProvider {
 
 		@Override
 		public void setUpdated(String table, int handle) {
-			Vector<String> tablesUpdatedInUTLHandle = getTablesUpdatedInUTL(handle);
-			if (isEnabled() && ! tablesUpdatedInUTLHandle.contains(table))
-				tablesUpdatedInUTLHandle.add(table);
-			
+			if (isEnabled()) {
+				Vector<String> tablesUpdatedInUTLHandle = getTablesUpdatedInUTL(handle);
+				if (!tablesUpdatedInUTLHandle.contains(table))
+					tablesUpdatedInUTLHandle.add(table);
+			}
 		}
 
 		private Vector<String> getTablesUpdatedInUTL(Integer handle){


### PR DESCRIPTION
New data was always being added to "tablesUpdatedInUTL" variable and never being cleared when SD smart cache was not enabled. Issue: 106111