### PR TITLE
Bump wss4j from version 1.6.19 to version 2.4.3

### DIFF
--- a/wrappercommon/pom.xml
+++ b/wrappercommon/pom.xml
@@ -34,11 +34,13 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.ws.security</groupId>
-			<artifactId>wss4j</artifactId>
-			<version>1.6.19</version>			
-		</dependency>		        			
+        <dependency>
+            <groupId>org.apache.wss4j</groupId>
+            <artifactId>wss4j</artifactId>
+            <version>2.4.3</version>
+            <type>pom</type>
+        </dependency>
+
 	</dependencies>	
 
 	<build>


### PR DESCRIPTION
Issue:102316
Update the library to fix transitive dependencies issues
#GXSEC