### PR TITLE
Bump bouncy castle libraries to version 1.78.1

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.75</version>
+			<version>1.78.1</version>
 		</dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/gxcryptocommon/pom.xml
+++ b/gxcryptocommon/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk18on</artifactId>
-			<version>1.75</version>
+			<version>1.78.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.santuario</groupId>


### PR DESCRIPTION
Issue:108498

Bump bouncy castle libraries from version 1.76 to version 1.78.1.

It updates the jars bcprov-jdk18on, bcutil-jdk18on and bcpkix-jdk18on.

- CVE-2024-34447
- CVE-2024-29857
- CVE-2024-30171
- CVE-2024-30172

#GXSEC