### PR TITLE
Bump commons-codec to version 1.15

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.9</version>
+			<version>1.15</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>


### PR DESCRIPTION
Issue:108682

Bump commons-codec from version 1.9 to version 1.15 due to housekeeping.

#GXSEC