### PR TITLE
Remove gxClassR dependency from CloudStorage libs

### DIFF
--- a/gxcloudstorage-awss3-v1/pom.xml
+++ b/gxcloudstorage-awss3-v1/pom.xml
@@ -14,11 +14,6 @@
     <name>GeneXus AWS S3 (V1) Cloud Storage</name>
 
 	<dependencies>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>gxclassR</artifactId>
-			<version>${project.version}</version>
-		</dependency>
         <dependency>
             <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>

--- a/gxcloudstorage-awss3-v1/pom.xml
+++ b/gxcloudstorage-awss3-v1/pom.xml
@@ -16,6 +16,12 @@
 	<dependencies>
         <dependency>
             <groupId>com.genexus</groupId>
+            <artifactId>gxclassR</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gxcloudstorage-awss3-v1/src/main/java/com/genexus/db/driver/ExternalProviderS3V1.java
+++ b/gxcloudstorage-awss3-v1/src/main/java/com/genexus/db/driver/ExternalProviderS3V1.java
@@ -8,7 +8,6 @@ import com.amazonaws.services.s3.S3ClientOptions;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import com.amazonaws.HttpMethod;
-import com.genexus.Application;
 import com.genexus.util.GXService;
 import com.genexus.util.StorageUtils;
 import com.genexus.StructSdtMessages_Message;
@@ -28,6 +27,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
 
 public class ExternalProviderS3V1 extends ExternalProviderBase implements ExternalProvider  {
 	private static Logger logger = LogManager.getLogger(ExternalProviderS3V1.class);
@@ -72,10 +72,6 @@ public class ExternalProviderS3V1 extends ExternalProviderBase implements Extern
 
 	public String getName(){
 		return NAME;
-	}
-
-	public ExternalProviderS3V1(String service) throws Exception{
-		this(Application.getGXServices().get(service));
 	}
 
 	public ExternalProviderS3V1() throws Exception{

--- a/gxcloudstorage-awss3-v2/pom.xml
+++ b/gxcloudstorage-awss3-v2/pom.xml
@@ -21,11 +21,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>gxclassR</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>

--- a/gxcloudstorage-awss3-v2/pom.xml
+++ b/gxcloudstorage-awss3-v2/pom.xml
@@ -15,6 +15,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.genexus</groupId>
+            <artifactId>gxclassR</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>gxclassR</artifactId>
             <version>${project.version}</version>

--- a/gxcloudstorage-awss3-v2/src/main/java/com/genexus/db/driver/ExternalProviderS3V2.java
+++ b/gxcloudstorage-awss3-v2/src/main/java/com/genexus/db/driver/ExternalProviderS3V2.java
@@ -19,7 +19,6 @@ import software.amazon.awssdk.utils.IoUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
-import com.genexus.Application;
 import com.genexus.util.GXService;
 import com.genexus.util.StorageUtils;
 import com.genexus.StructSdtMessages_Message;
@@ -78,10 +77,6 @@ public class ExternalProviderS3V2 extends ExternalProviderBase implements Extern
 
 	public String getName() {
 		return NAME;
-	}
-
-	public ExternalProviderS3V2(String service) throws Exception {
-		this(Application.getGXServices().get(service));
 	}
 
 	public ExternalProviderS3V2() throws Exception {

--- a/gxcloudstorage-azureblob/pom.xml
+++ b/gxcloudstorage-azureblob/pom.xml
@@ -15,11 +15,6 @@
 
 	<dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>gxclassR</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>

--- a/gxcloudstorage-azureblob/pom.xml
+++ b/gxcloudstorage-azureblob/pom.xml
@@ -16,6 +16,12 @@
 	<dependencies>
         <dependency>
             <groupId>com.genexus</groupId>
+            <artifactId>gxclassR</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gxcloudstorage-azureblob/src/main/java/com/genexus/db/driver/ExternalProviderAzureStorage.java
+++ b/gxcloudstorage-azureblob/src/main/java/com/genexus/db/driver/ExternalProviderAzureStorage.java
@@ -1,6 +1,5 @@
 package com.genexus.db.driver;
 
-import com.genexus.Application;
 import com.genexus.StructSdtMessages_Message;
 import com.genexus.util.GXService;
 import com.genexus.util.StorageUtils;
@@ -47,9 +46,6 @@ public class ExternalProviderAzureStorage extends ExternalProviderBase implement
 	private String privateContainerName;
 	private String publicContainerName;
 
-	public ExternalProviderAzureStorage(String service) throws Exception {
-		this(Application.getGXServices().get(service));
-	}
 
 	private void init() throws Exception {
 		try {

--- a/gxcloudstorage-common/pom.xml
+++ b/gxcloudstorage-common/pom.xml
@@ -16,7 +16,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>gxclassR</artifactId>
+			<artifactId>gxcommon</artifactId>
 			<version>${project.version}</version>
 		</dependency>
     </dependencies>

--- a/gxcloudstorage-common/pom.xml
+++ b/gxcloudstorage-common/pom.xml
@@ -19,6 +19,21 @@
 			<artifactId>gxcommon</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/gxcloudstorage-googlecloudstorage/pom.xml
+++ b/gxcloudstorage-googlecloudstorage/pom.xml
@@ -15,11 +15,6 @@
 
 	<dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>gxclassR</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>

--- a/gxcloudstorage-googlecloudstorage/pom.xml
+++ b/gxcloudstorage-googlecloudstorage/pom.xml
@@ -16,6 +16,12 @@
 	<dependencies>
         <dependency>
             <groupId>com.genexus</groupId>
+            <artifactId>gxclassR</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gxcloudstorage-googlecloudstorage/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
+++ b/gxcloudstorage-googlecloudstorage/src/main/java/com/genexus/db/driver/ExternalProviderGoogle.java
@@ -1,6 +1,5 @@
 package com.genexus.db.driver;
 
-import com.genexus.Application;
 import com.genexus.StructSdtMessages_Message;
 import com.genexus.util.GXService;
 import com.genexus.util.StorageUtils;
@@ -55,10 +54,6 @@ public class ExternalProviderGoogle extends ExternalProviderBase implements Exte
 	public ExternalProviderGoogle() throws Exception{
 		super();
 		initialize();
-	}
-
-	public ExternalProviderGoogle(String service) throws Exception{
-		this(Application.getGXServices().get(service));
 	}
 
 	public ExternalProviderGoogle(GXService providerService) throws Exception{

--- a/gxcloudstorage-ibmcos/pom.xml
+++ b/gxcloudstorage-ibmcos/pom.xml
@@ -15,11 +15,6 @@
 
 	<dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>gxclassR</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>

--- a/gxcloudstorage-ibmcos/pom.xml
+++ b/gxcloudstorage-ibmcos/pom.xml
@@ -16,6 +16,12 @@
 	<dependencies>
         <dependency>
             <groupId>com.genexus</groupId>
+            <artifactId>gxclassR</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.genexus</groupId>
             <artifactId>gxcloudstorage-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gxcloudstorage-ibmcos/src/main/java/com/genexus/db/driver/ExternalProviderIBM.java
+++ b/gxcloudstorage-ibmcos/src/main/java/com/genexus/db/driver/ExternalProviderIBM.java
@@ -1,9 +1,7 @@
 package com.genexus.db.driver;
 
-import com.genexus.Application;
 import com.genexus.StructSdtMessages_Message;
 import com.genexus.util.GXService;
-import com.genexus.util.GXServices;
 import com.genexus.util.StorageUtils;
 import com.ibm.cloud.objectstorage.ClientConfiguration;
 import com.ibm.cloud.objectstorage.HttpMethod;
@@ -56,15 +54,6 @@ public class ExternalProviderIBM extends ExternalProviderBase implements Externa
     private String folder;
     private String endpointUrl;
 	private int defaultExpirationMinutes = DEFAULT_EXPIRATION_MINUTES;
-
-    /* For compatibility reasons with GX16 U6 or lower*/
-    public ExternalProviderIBM() throws Exception {
-        this(GXServices.STORAGE_SERVICE);
-    }
-
-    public ExternalProviderIBM(String service) throws Exception {
-        this(Application.getGXServices().get(service));
-    }
 
     public ExternalProviderIBM(GXService providerService) throws Exception {
     	super(providerService);

--- a/gxcloudstorage-ibmcos/src/main/java/com/genexus/db/driver/ExternalProviderIBM.java
+++ b/gxcloudstorage-ibmcos/src/main/java/com/genexus/db/driver/ExternalProviderIBM.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-
 public class ExternalProviderIBM extends ExternalProviderBase implements ExternalProvider {
 
 	private static Logger logger = LogManager.getLogger(ExternalProviderIBM.class);

--- a/java/src/main/java/com/genexus/Application.java
+++ b/java/src/main/java/com/genexus/Application.java
@@ -184,7 +184,7 @@ public class Application
 				throw new InternalError("Unrecognized External Provider class (ClassNotFound) : " + providerService.getName() + " / " + providerService.getClassName());
 			}
 			try {
-				externalProviderImpl = (ExternalProvider) providerClass.getConstructor(String.class).newInstance(service);
+				externalProviderImpl = (ExternalProvider) providerClass.getConstructor(GXService.class).newInstance(providerService);
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
Cloud Storage dependencies should not depend on gxClassR.

gxClassR depends on JavaXWrapper and JakartaWrapper, so when adding Cloudstorage dependencies , it also adds both (javax and jakarta) dependencies. This will fail at runtime. 