### PR TITLE
Allow use user and password encrypted in Datasource definition

### DIFF
--- a/common/src/main/java/com/genexus/util/IniFile.java
+++ b/common/src/main/java/com/genexus/util/IniFile.java
@@ -245,6 +245,10 @@ public class IniFile {
 
 	public String getPropertyEncrypted(String section, String key) {
 		String val = getProperty(section, key);
+		return decryptValue(val, key);
+	}
+
+	public String decryptValue(String val, String key) {
 		if (val != null) {
 			int checkSumLength = Encryption.getCheckSumLength();
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -169,6 +169,11 @@
             <artifactId>opentelemetry-instrumentation-annotations</artifactId>
             <version>${io.opentelemetry.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.9.0</version> <!-- Verifica la última versión disponible -->
+        </dependency>
     </dependencies>
 	
 	<build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.9.0</version> <!-- Verifica la última versión disponible -->
+            <version>2.9.0</version>
         </dependency>
     </dependencies>
 	

--- a/java/src/main/java/com/genexus/db/EncryptedDataSourceFactory.java
+++ b/java/src/main/java/com/genexus/db/EncryptedDataSourceFactory.java
@@ -1,0 +1,53 @@
+package com.genexus.db;
+
+import com.genexus.specific.java.Connect;
+import com.genexus.util.IniFile;
+import org.apache.commons.dbcp2.BasicDataSourceFactory;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.Reference;
+import javax.naming.spi.ObjectFactory;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Properties;
+
+public class EncryptedDataSourceFactory implements ObjectFactory {
+
+	private final static String USERNAME = "username";
+	private final static String PASSWORD = "password";
+
+	@Override
+	public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) throws Exception {
+		if (obj instanceof Reference) {
+			Reference ref = (Reference) obj;
+			Properties properties = new Properties();
+
+			Enumeration<javax.naming.RefAddr> addresses = ref.getAll();
+			while (addresses.hasMoreElements()) {
+				javax.naming.RefAddr addr = addresses.nextElement();
+				properties.setProperty(addr.getType(), (String) addr.getContent());
+			}
+
+			IniFile config;
+			try {
+				Class<?> gxCfg = Class.forName(properties.getProperty("gxcfg"));
+				Connect.init();
+				config = com.genexus.ConfigFileFinder.getConfigFile(null, "client.cfg", gxCfg);
+			}
+			catch (Exception e) {
+				System.out.println("ERROR com.genexus.db.EncryptedDataSourceFactory - Could not found gxcfg Class");
+				return null;
+			}
+
+			String encryptedUsername = properties.getProperty(USERNAME);
+			properties.setProperty(USERNAME, config.decryptValue(encryptedUsername, "USER_ID"));
+
+			String encryptedPassword = properties.getProperty(PASSWORD);
+			properties.setProperty(PASSWORD, config.decryptValue(encryptedPassword, "USER_PASSWORD"));
+
+			return BasicDataSourceFactory.createDataSource(properties);
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
To use this feature DataSource definition must include factory property with value "com.genexus.db.EncryptedDataSourceFactory" and gxcfg property with value "<java_package_name>.GXcfg"

SAC #60026