### PR TITLE
ApiObject Forward log changed to debug in order to not clutter the log

### DIFF
--- a/java/src/main/java/com/genexus/filters/APIObjectFilter.java
+++ b/java/src/main/java/com/genexus/filters/APIObjectFilter.java
@@ -44,7 +44,7 @@ public class APIObjectFilter extends Filter {
 				if ( qString != null && !qString.isEmpty()) {
 					fwdURI = fwdURI + QS_SEP + qString;
 				}
-				logger.info("Forwarding from " + path +" to: " + fwdURI) ;
+				logger.debug("Forwarding from " + path +" to: " + fwdURI) ;
 				httpRequest.getRequestDispatcher(fwdURI).forward(request,response);
             }
             else {


### PR DESCRIPTION
Reducing the LogLevel of ApiObject Forwarding message From INFO to DEBUG in order not to clutter the Log Console. 

![image](https://github.com/user-attachments/assets/5bacc64f-aa1b-4566-8634-af2345ad3ae5)