### PR TITLE
Avoid Null Pointer Exception when GeneXus connection Pool checks if a…

### DIFF
--- a/java/src/main/java/com/genexus/db/driver/GXConnection.java
+++ b/java/src/main/java/com/genexus/db/driver/GXConnection.java
@@ -82,7 +82,7 @@ public final class GXConnection extends AbstractGXConnection implements Connecti
 
 	//JMX Properties
 	int numberRequest = 0;
-	java.util.Date timeLastRequest;
+	java.util.Date timeLastRequest = new java.util.Date();
 	String sentenceLastRequest;
 	String lastObjectExecuted;
 	boolean finishExecute = true;


### PR DESCRIPTION
… connection must be recycled.

Issue: 200842