### PR TITLE
fix: Remove undefined value

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -188,7 +188,6 @@ jobs:
     if: github.repository_owner == 'genexuslabs' && needs.build.outputs.SHOULD_DEPLOY == 'true'
     with: 
       VERSION: ${{ needs.build.outputs.MAVEN_VERSION }}
-      PACKAGE_NAMES: ${{ needs.build.outputs.PACKAGES_NAME }}
       COMMIT_MESSAGE: ${{ needs.build.outputs.COMMIT_MESSAGE }}
       COMMITTER: ${{ needs.build.outputs.LAST_COMMITTER }}
     secrets: inherit


### PR DESCRIPTION
The reusable workflow is already using the default value, remove the PACKAGES_NAME definition that is undefined.