### PR TITLE
Remove not useful redundant logging

### DIFF
--- a/gxweb/src/main/java/com/genexus/internet/HttpAjaxContext.java
+++ b/gxweb/src/main/java/com/genexus/internet/HttpAjaxContext.java
@@ -727,8 +727,7 @@ public class HttpAjaxContext extends HttpContextWeb
 		boolean fileExists = false;
 		try
 		{
-			fileExists = ApplicationContext.getInstance().checkIfResourceExist(getDefaultPath() + staticContentBase + fileName);
-			com.genexus.diagnostics.Log.info("Searching if file exists (" + fileName + "). Found: " + String.valueOf(fileExists));
+			fileExists = ApplicationContext.getInstance().checkIfResourceExist(getDefaultPath() + staticContentBase + fileName);			
 		}
 		catch (Exception e)
 		{

--- a/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
+++ b/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
@@ -70,8 +70,7 @@ public class HttpClientJavaLib extends GXHttpClient {
 		getPoolInstance();
 		ConnectionKeepAliveStrategy myStrategy = generateKeepAliveStrategy();
 		httpClientBuilder = HttpClients.custom().setConnectionManager(connManager).setConnectionManagerShared(true).setKeepAliveStrategy(myStrategy);
-		cookies = new BasicCookieStore();
-		logger.info("Using apache http client implementation");
+		cookies = new BasicCookieStore();		
 		streamsToClose = new Vector<>();
 	}
 


### PR DESCRIPTION
`2024-10-29T17:40:24,197 [http-nio-8080-exec-318] INFO  com.genexus.internet.HttpClientJavaLib - Using apache http client implementation`

`2024-10-29T17:40:11,544 [http-nio-8080-exec-315] INFO  com.genexus.logging - Searching if file exists (service-worker.js). Found: false`