### PR TITLE
- Fixed read of Byte fields in SAP Structures 

### DIFF
--- a/java/src/main/java/com/genexus/sap/EnterpriseConnect.java
+++ b/java/src/main/java/com/genexus/sap/EnterpriseConnect.java
@@ -217,7 +217,20 @@ public class EnterpriseConnect
 					String key = (String)keys.next();
 					int jcoType = jStruct.getMetaData().getType(key);	
 				
-					if( jObj.get(key) instanceof String )
+					if (jcoType == JCoMetaData.TYPE_BYTE)
+					{
+						if ( jStruct.getMetaData().getLength(key) <= 4)
+						{
+							jStruct.setValue(key, jObj.getInt(key));
+						}
+						else if ( jStruct.getMetaData().getLength(key) <= 8)
+						{
+							jStruct.setValue(key, jObj.getLong(key));						
+						}
+						else
+							jStruct.setValue(key, jObj.getString(key).getBytes());
+					}
+					else if( jObj.get(key) instanceof String )
 					{
 						jStruct.setValue(key, jObj.getString(key));
 					}					


### PR DESCRIPTION
Changed EnterpriseConnect.java .  Fixed read of Byte fields in SAP Structures 
When setting a byte Field from a structure in a SAP Function , an error occurred due to conversion problems, this happens for instance wit GUID fields packed in binary
for example,  the CAMPAIGN field in  BASPISDH1  ( type SYSUUID 16 )