### PR TITLE
Azure Functions Fixes

### DIFF
--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureBlobStorageHandler.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureBlobStorageHandler.java
@@ -1,6 +1,6 @@
 package com.genexus.cloud.serverless.azure.handler;
-import com.genexus.cloud.serverless.model.*;
 
+import com.genexus.cloud.serverless.model.*;
 import com.microsoft.azure.functions.annotation.*;
 import com.microsoft.azure.functions.ExecutionContext;
 
@@ -17,14 +17,25 @@ public class AzureBlobStorageHandler extends AzureEventHandler{
 		super();
 	}
 	public void run(
-		@BlobTrigger(name = "content", source = "EventGrid", path = "%blob_path%", dataType = "binary") byte[] content,
+		@BlobTrigger(name = "content", source = "EventGrid", path = "test-triggerinput-java/{name}", dataType = "binary") byte[] content,
 		@BindingName("name") String name,
 		final ExecutionContext context
 	) throws Exception {
 
 		context.getLogger().info("GeneXus Blob Storage trigger handler. Function processed: " + context.getFunctionName() + " Invocation Id: " + context.getInvocationId());
 		setupServerlessMappings(context.getFunctionName());
-
+		String functionName = context.getFunctionName().trim().toUpperCase();
+		String storageEnvVar = String.format("GX_AZURE_%s_BLOB_STORAGE", functionName);
+		String containerEnvVar = String.format("GX_AZURE_%s_BLOB_STORAGE_CONTAINER", functionName);
+		String storageAccount = System.getenv(storageEnvVar);
+		String containerName = System.getenv(containerEnvVar);
+		String blobUri;
+		if (storageAccount != null && !storageAccount.isEmpty() && containerName != null && !containerName.isEmpty())
+			blobUri = String.format("https://%s.blob.core.windows.net/%s/%s", storageAccount, containerName, "name");
+		else {
+			blobUri = "name";
+			context.getLogger().warning(String.format("Could not return complete URI. Please configure GX_AZURE_%s_BLOB_STORAGE and GX_AZURE_%s_BLOB_STORAGE_CONTAINER app settings.",functionName,functionName));
+		}
 		switch (executor.getMethodSignatureIdx()) {
 			case 0:
 				EventMessage msg = new EventMessage();
@@ -32,26 +43,17 @@ public class AzureBlobStorageHandler extends AzureEventHandler{
 				msg.setMessageSourceType(EventMessageSourceType.BLOB);
 				Instant nowUtc = Instant.now();
 				msg.setMessageDate(Date.from(nowUtc));
-				msg.setMessageData(Base64.getEncoder().encodeToString(content));
 				List<EventMessageProperty> msgAtts = msg.getMessageProperties();
+				msg.setMessageData(blobUri);
 				msgAtts.add(new EventMessageProperty("Id", context.getInvocationId()));
 				msgAtts.add(new EventMessageProperty("name", name));
-
 				msgs.add(msg);
 				break;
 			case 1:
 			case 2:
-				rawMessage = Base64.getEncoder().encodeToString(content);
+				rawMessage = blobUri;
 		}
-		try {
-			EventMessageResponse response = dispatchEvent(msgs, rawMessage);
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error("HandleRequest execution error", e);
-			throw e; 		//Throw the exception so the runtime can Retry the operation.
-		}
+		ExecuteDynamic(msgs,rawMessage);
 	}
 }
+

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureEventGridHandler.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureEventGridHandler.java
@@ -19,22 +19,10 @@ public class AzureEventGridHandler  extends AzureEventHandler {
 	public void run(
 		@EventGridTrigger(name = "eventgridEvent") EventGridEvent event,
 		final ExecutionContext context) throws Exception {
-
 		context.getLogger().info("GeneXus Event Grid trigger handler. Function processed: " + context.getFunctionName() + " Invocation Id: " + context.getInvocationId());
-
 		setupServerlessMappings(context.getFunctionName());
 		setupEventGridMessage(event);
-
-		try {
-			EventMessageResponse response = dispatchEvent(msgs, rawMessage);
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error("HandleRequest execution error", e);
-			throw e; 		//Throw the exception so the runtime can Retry the operation.
-		}
+		ExecuteDynamic(msgs, rawMessage);
 	}
 
 	protected void setupEventGridMessage(EventGridEvent event) {
@@ -46,15 +34,12 @@ public class AzureEventGridHandler  extends AzureEventHandler {
 				msg.setMessageVersion(event.getDataVersion());
 				msg.setMessageDate(new Date());
 				msg.setMessageData(event.getData().toString());
-
 				List<EventMessageProperty> msgAtts = msg.getMessageProperties();
 				msgAtts.add(new EventMessageProperty("Id", event.getId()));
-
 				msgAtts.add(new EventMessageProperty("Subject",event.getSubject()));
 				msgAtts.add(new EventMessageProperty("Topic",event.getTopic()));
 				if (event.getEventTime()!= null)
 					msgAtts.add(new EventMessageProperty("EventTime",event.getEventTime().toString()));
-
 				msgs.add(msg);
 				break;
 			case 1:

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureFunctionConfiguration.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureFunctionConfiguration.java
@@ -12,13 +12,16 @@ public class AzureFunctionConfiguration extends ServerlessFunctionConfiguration 
 
 	public AzureFunctionConfiguration() {
 	}
+
 	public AzureFunctionConfiguration(String functionName, String gxEntrypoint) {
 		this.functionName = functionName;
 		this.gxEntrypoint = gxEntrypoint;
 	}
+
 	public void setFunctionName(String functionName) {
 		this.functionName = functionName;
 	}
+
 	public void setGXEntrypoint(String gxEntrypoint) {
 		this.gxEntrypoint = gxEntrypoint;
 	}
@@ -30,6 +33,7 @@ public class AzureFunctionConfiguration extends ServerlessFunctionConfiguration 
 	public String getGXEntrypoint() {
 		return gxEntrypoint;
 	}
+
 	@Override
 	public boolean isValidConfiguration () {
 		return functionName != null && !functionName.trim().isEmpty() && gxEntrypoint != null && !gxEntrypoint.trim().isEmpty();

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureFunctionConfigurationHelper.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureFunctionConfigurationHelper.java
@@ -20,7 +20,6 @@ public class AzureFunctionConfigurationHelper {
 
 	public static List<AzureFunctionConfiguration> getFunctionsMapConfiguration() throws FunctionConfigurationException {
 		File configFile = new File(FUNCTION_CONFIG_PATH);
-
 		if (configFile.exists()) {
 			try {
 				String jsonConfig = new String(Files.readAllBytes(Paths.get(FUNCTION_CONFIG_PATH)));

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureQueueHandler.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureQueueHandler.java
@@ -1,10 +1,8 @@
 package com.genexus.cloud.serverless.azure.handler;
 
 import com.genexus.cloud.serverless.model.*;
-
 import com.microsoft.azure.functions.annotation.*;
 import com.microsoft.azure.functions.ExecutionContext;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.*;
@@ -13,6 +11,7 @@ public class AzureQueueHandler extends AzureEventHandler {
 	public AzureQueueHandler() throws Exception {
 		super();
 	}
+
 	public void run(
 		@QueueTrigger(name = "message", queueName = "%queue_name%") String message,
 		@BindingName("Id") final String id,
@@ -41,15 +40,6 @@ public class AzureQueueHandler extends AzureEventHandler {
 				msgAtts.add(new EventMessageProperty("PopReceipt", popReceipt));
 				msgs.add(msg);
 		}
-		try {
-			EventMessageResponse response = dispatchEvent(msgs, message);
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error("HandleRequest execution error", e);
-			throw e; 		//Throw the exception so the runtime can Retry the operation.
-		}
+		ExecuteDynamic(msgs, message);
 	}
 }

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusQueueHandler.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusQueueHandler.java
@@ -2,7 +2,6 @@ package com.genexus.cloud.serverless.azure.handler;
 
 import com.genexus.cloud.serverless.helpers.ServiceBusBatchMessageProcessor;
 import com.genexus.cloud.serverless.helpers.ServiceBusProcessedMessage;
-import com.genexus.cloud.serverless.model.*;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.annotation.*;
 
@@ -22,15 +21,6 @@ public class AzureServiceBusQueueHandler extends AzureEventHandler {
 		setupServerlessMappings(context.getFunctionName());
 		ServiceBusBatchMessageProcessor queueBatchMessageProcessor = new ServiceBusBatchMessageProcessor();
 		ServiceBusProcessedMessage queueMessage = queueBatchMessageProcessor.processQueueMessage(context, executor, messages);
-		try {
-			EventMessageResponse response = dispatchEvent(queueMessage.getEventMessages(),queueMessage.getRawMessage());
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error("HandleRequest execution error", e);
-			throw e; 		//Throw the exception so the runtime can Retry the operation.
-		}
+		ExecuteDynamic(queueMessage.getEventMessages(),queueMessage.getRawMessage());
 	}
 }

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusQueueSingleMsgHandler.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusQueueSingleMsgHandler.java
@@ -2,7 +2,6 @@ package com.genexus.cloud.serverless.azure.handler;
 
 import com.genexus.cloud.serverless.helpers.ServiceBusProcessedMessage;
 import com.genexus.cloud.serverless.helpers.ServiceBusSingleMessageProcessor;
-import com.genexus.cloud.serverless.model.*;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.annotation.BindingName;
 import com.microsoft.azure.functions.annotation.Cardinality;
@@ -26,15 +25,6 @@ public class AzureServiceBusQueueSingleMsgHandler extends AzureEventHandler {
 		setupServerlessMappings(context.getFunctionName());
 		ServiceBusSingleMessageProcessor queueSingleMessageProcessor = new ServiceBusSingleMessageProcessor();
 		ServiceBusProcessedMessage queueMessage = queueSingleMessageProcessor.processQueueMessage(executor,messageId,enqueuedTimeUtc,context,message);
-		try {
-			EventMessageResponse response = dispatchEvent(queueMessage.getEventMessages(), queueMessage.getRawMessage());
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error("HandleRequest execution error", e);
-			throw e;        //Throw the exception so the runtime can Retry the operation.
-		}
+		ExecuteDynamic(queueMessage.getEventMessages(), queueMessage.getRawMessage());
 	}
 }

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusTopicHandler.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusTopicHandler.java
@@ -2,7 +2,6 @@ package com.genexus.cloud.serverless.azure.handler;
 
 import com.genexus.cloud.serverless.helpers.ServiceBusBatchMessageProcessor;
 import com.genexus.cloud.serverless.helpers.ServiceBusProcessedMessage;
-import com.genexus.cloud.serverless.model.*;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.annotation.*;
 
@@ -22,15 +21,6 @@ public class AzureServiceBusTopicHandler extends AzureEventHandler {
 		setupServerlessMappings(context.getFunctionName());
 		ServiceBusBatchMessageProcessor queueBatchMessageProcessor = new ServiceBusBatchMessageProcessor();
 		ServiceBusProcessedMessage queueMessage = queueBatchMessageProcessor.processQueueMessage(context, executor, messages);
-		try {
-			EventMessageResponse response = dispatchEvent(queueMessage.getEventMessages(), queueMessage.getRawMessage());
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error("HandleRequest execution error", e);
-			throw e; 		//Throw the exception so the runtime can Retry the operation.
-		}
+		ExecuteDynamic(queueMessage.getEventMessages(), queueMessage.getRawMessage());
 	}
 }

--- a/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusTopicSingleMsgHandler.java
+++ b/gxazureserverless/src/main/java/com/genexus/cloud/serverless/azure/handler/AzureServiceBusTopicSingleMsgHandler.java
@@ -2,7 +2,6 @@ package com.genexus.cloud.serverless.azure.handler;
 
 import com.genexus.cloud.serverless.helpers.ServiceBusProcessedMessage;
 import com.genexus.cloud.serverless.helpers.ServiceBusSingleMessageProcessor;
-import com.genexus.cloud.serverless.model.*;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.annotation.BindingName;
 import com.microsoft.azure.functions.annotation.Cardinality;
@@ -26,16 +25,7 @@ public class AzureServiceBusTopicSingleMsgHandler extends AzureEventHandler {
 		setupServerlessMappings(context.getFunctionName());
 		ServiceBusSingleMessageProcessor queueSingleMessageProcessor = new ServiceBusSingleMessageProcessor();
 		ServiceBusProcessedMessage queueMessage = queueSingleMessageProcessor.processQueueMessage(executor,messageId,enqueuedTimeUtc,context,message);
-		try {
-			EventMessageResponse response = dispatchEvent(queueMessage.getEventMessages(),queueMessage.getRawMessage());
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error("HandleRequest execution error", e);
-			throw e;        //Throw the exception so the runtime can Retry the operation.
-		}
+		ExecuteDynamic(queueMessage.getEventMessages(),queueMessage.getRawMessage());
 	}
 }
 

--- a/gxazureserverless/src/test/java/com/genexus/cloud/azure/events/TestAzureQueueHandler.java
+++ b/gxazureserverless/src/test/java/com/genexus/cloud/azure/events/TestAzureQueueHandler.java
@@ -28,7 +28,6 @@ public class TestAzureQueueHandler {
 
 		context = new MockExecutionContext("TestQueueRaw","13e2d1f9-6838-4927-a6a8-0160e8601ab0");
 		queueFunction.run(testMessage,id,dequeCount,expirationTime,insertionTime, nextVisibleTime,popReceipt,context);
-
 		assertNotNull(context.getLogger());
 		context.getLogger().info("Logger is not null");
 
@@ -45,7 +44,6 @@ public class TestAzureQueueHandler {
 
 		context = new MockExecutionContext("TestQueueEventMessage","758093bf-68c1-47a5-8f93-cc2882e961e7");
 		queueFunction.run(testMessage,id,dequeCount,expirationTime,insertionTime, nextVisibleTime,popReceipt,context);
-
 		assertNotNull(context.getLogger());
 		context.getLogger().info("Logger is not null");
 	}

--- a/gxserverlesscommon/src/main/java/com/genexus/cloud/serverless/ServerlessBaseEventHandler.java
+++ b/gxserverlesscommon/src/main/java/com/genexus/cloud/serverless/ServerlessBaseEventHandler.java
@@ -55,22 +55,9 @@ public abstract class ServerlessBaseEventHandler <T extends ServerlessFunctionCo
 		InitializeServerlessConfig();
 	}
 
-	protected EventMessageResponse dispatchEvent(EventMessages eventMessages, String rawMessageBody) throws Exception {
-		EventMessagesList eventMessagesList = new EventMessagesList();
-		return dispatchEvent(eventMessages,eventMessagesList,rawMessageBody);
-	}
-
 	protected void ExecuteDynamic(EventMessages msgs, String rawMessage) throws Exception {
-		try {
-			EventMessageResponse response = dispatchEvent(msgs, rawMessage);
-			if (response.hasFailed()) {
-				logger.error(String.format("Messages were not handled. Error: %s", response.getErrorMessage()));
-				throw new RuntimeException(response.getErrorMessage()); //Throw the exception so the runtime can Retry the operation.
-			}
-		} catch (Exception e) {
-			logger.error(String.format("HandleRequest execution error: %s",e));
-			throw e; 		//Throw the exception so the runtime can Retry the operation.
-		}
+		EventMessagesList eventMessagesList = new EventMessagesList();
+		ExecuteDynamic(msgs,eventMessagesList,rawMessage);
 	}
 	protected void ExecuteDynamic(EventMessages msgs, EventMessagesList eventMessagesList, String rawMessage) throws Exception {
 		try {

--- a/java/src/main/java/com/genexus/GXDbFile.java
+++ b/java/src/main/java/com/genexus/GXDbFile.java
@@ -134,7 +134,8 @@ public class GXDbFile
 		{
 			name = PrivateUtilities.encodeFileName(name);
 		}
-		name = PrivateUtilities.checkFileNameLength(file.replace(name, ""), name, type);
+		else
+			name = PrivateUtilities.checkFileNameLength(file.replace(name, ""), name, type);
 				
 		if (!addScheme)
 		{


### PR DESCRIPTION
Improvements to impl to Issue:20064
- Use Function Execution Context logger inside the Functions, because the messages are thrown automatically to App Insights.
- Avoid managing the blob binaries in Blob Functions. Just return URI. The Java SDK has limitations related to this. They do not offer any metadata. An idea is to use a Blob Client to extract metadata. That needs an Authentication (it can be Managed). Leave it for another impl due to SDK limitations.

