### PR TITLE
Support Reading CloudServices.config from File System and Classpath

### DIFF
--- a/common/src/main/java/com/genexus/xml/XMLReader.java
+++ b/common/src/main/java/com/genexus/xml/XMLReader.java
@@ -814,7 +814,27 @@ public class XMLReader implements XMLDocumentHandler, XMLErrorHandler, XMLDTDHan
 		}
 	}
 
-	
+	public void openFromInputStream(InputStream inputStream)
+	{
+		reset();
+		try
+		{
+			streamToClose = inputStream;
+			if (documentEncoding.length() > 0)
+				inputSource = new XMLInputSource(null, null, null, inputStream, documentEncoding);
+			else
+				inputSource = new XMLInputSource(null, null, null, inputStream, null);
+
+			parserConfiguration.setInputSource(inputSource);
+		}
+		catch (IOException e)
+		{
+			errCode = ERROR_IO;
+			errDescription = e.getMessage();
+		}
+	}
+
+
 	public void openFromString(String s)
 	{
 		reset();

--- a/java/src/main/java/com/genexus/util/GXServices.java
+++ b/java/src/main/java/com/genexus/util/GXServices.java
@@ -126,7 +126,7 @@ public class GXServices {
 
 	public static void loadFromStream(InputStream inputStream, String source, GXServices services) throws IOException {
 		XMLReader reader = new XMLReader();
-		reader.open(inputStream);
+		reader.openFromInputStream(inputStream);
 		reader.readType(1, "Services");
 		reader.read();
 		if (reader.getErrCode() == 0) {


### PR DESCRIPTION
## **Support Reading Services Configuration from File System and Classpath**

### **Issue**  
When deploying the application as a **JAR** (rather than a web application), it currently expects the service configuration files (`SERVICES_DEV_FILE` and `SERVICES_FILE`) to be available **only in the file system**. If these files are missing, the application fails to load the configurations instead of checking if they exist in the JAR’s classpath.

Additionally, if `SERVICES_DEV_FILE` is found, the execution stops without attempting to load `SERVICES_FILE`, which may contain additional configurations.

### **Solution**  
This PR enhances the configuration loading mechanism to:
- **Support reading from both the file system and the JAR classpath** using `ClassLoader.getResourceAsStream`.
- **Ensure `SERVICES_FILE` is always attempted**, even if `SERVICES_DEV_FILE` is successfully loaded.
- **Improve error handling** by logging detailed messages when files fail to load.

### **Changes Made**  
1. **Added `readFromClasspath` method**:  
   - Uses `ClassLoader.getResourceAsStream` to attempt reading files from the JAR classpath if they are missing in the file system.

2. **Modified `readServices` method**:
   - Attempts to read `SERVICES_DEV_FILE` from both **file system** and **classpath**.
   - Ensures `SERVICES_FILE` is always attempted **after** `SERVICES_DEV_FILE`, regardless of whether the first file was found or not.

3. **Refactored `loadFromFile` to `loadFromStream`**:
   - Introduced `loadFromStream` to handle both **file-based** and **classpath-based** input streams.
   - Used **try-with-resources** to properly close input streams.

4. **Improved error logging**:
   - Logs whether a file is missing in the file system or classpath.
   - Logs error details when reading from the classpath fails.

### **Expected Behavior After Merge**  
✔ If `SERVICES_DEV_FILE` is found, it loads but **does not prevent** `SERVICES_FILE` from loading.  
✔ If `SERVICES_FILE` is missing in the **file system**, it will still be attempted from the **JAR classpath**.  
✔ Ensures configurations are correctly loaded even when packaged inside a JAR.  
✔ Eliminates failures caused by missing configuration files in JAR deployments.

### **Testing**  
- **Case 1**: `SERVICES_DEV_FILE` and `SERVICES_FILE` exist in the file system → ✅ Both should load.  
- **Case 2**: `SERVICES_DEV_FILE` exists, `SERVICES_FILE` is missing → ✅ Loads `SERVICES_DEV_FILE`, tries `SERVICES_FILE` in the classpath.  
- **Case 3**: Neither file exists in the file system → ✅ Attempts to load both from the classpath.  
- **Case 4**: Files exist only in the classpath → ✅ Reads from the JAR successfully.  

### **Impact**  
- **Ensures compatibility with JAR deployments** by allowing configuration files inside JARs.
- **Prevents unexpected failures** when files are not available in the local file system.
- **Improves flexibility** by ensuring configurations are loaded correctly in all deployment scenarios.  

🚀 **Ready for review!**