### PR TITLE
Charset of response must be geted from response.getEntity() instead o…

### DIFF
--- a/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
+++ b/java/src/main/java/com/genexus/internet/HttpClientJavaLib.java
@@ -728,7 +728,7 @@ public class HttpClientJavaLib extends GXHttpClient {
 			return "";
 		try {
 			this.setEntity();
-			Charset charset = ContentType.getOrDefault(entity).getCharset();
+			Charset charset = ContentType.getOrDefault(response.getEntity()).getCharset();
 			String res = EntityUtils.toString(entity, charset);
 			if (res.matches(".*[Ã-ÿ].*")) {
 				res = EntityUtils.toString(entity, StandardCharsets.UTF_8);


### PR DESCRIPTION
…f the ByteArrayEntity that is build in setEntity method