### PR TITLE
Android, Fix JsonObjectWrapper to load internal map on constructor.

### DIFF
--- a/android/src/main/java/com/genexus/specific/android/AndroidJSONSerialization.java
+++ b/android/src/main/java/com/genexus/specific/android/AndroidJSONSerialization.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class AndroidJSONSerialization implements IExtensionJSONSerialization {
+	
 	@Override
 	public Iterator<Map.Entry<String, Object>> getJSONObjectIterator(JSONObjectWrapper obj) {
 		Map<String, Object> map = new LinkedHashMap<>();
@@ -23,5 +24,16 @@ public class AndroidJSONSerialization implements IExtensionJSONSerialization {
 	@Override
 	public JSONTokener getJSONTokener(String s) {
 		return new AndroidJSONTokenerWrapper(s);
+	}
+
+	@Override
+	public Map<String, Object> getJSONObjectMap(JSONObjectWrapper obj) {
+		Map<String, Object> map = new LinkedHashMap<>();
+		for (Iterator<String> it = obj.keys(); it.hasNext(); ) {
+			String k = it.next();
+			map.put(k, obj.get(k)); // add key and value to map result
+		}
+		return map;
+		
 	}
 }

--- a/common/src/main/java/com/genexus/common/interfaces/IExtensionJSONSerialization.java
+++ b/common/src/main/java/com/genexus/common/interfaces/IExtensionJSONSerialization.java
@@ -9,4 +9,5 @@ import java.util.Map;
 public interface IExtensionJSONSerialization {
 	Iterator<Map.Entry<String, Object>> getJSONObjectIterator(JSONObjectWrapper obj);
 	JSONTokener getJSONTokener(String s);
+	public Map<String, Object> getJSONObjectMap(JSONObjectWrapper obj);
 }

--- a/common/src/main/java/com/genexus/json/JSONObjectWrapper.java
+++ b/common/src/main/java/com/genexus/json/JSONObjectWrapper.java
@@ -22,15 +22,12 @@ public class JSONObjectWrapper extends JSONObject implements java.io.Serializabl
 			? SpecificImplementation.JsonSerialization.getJSONTokener(string)
 			: new JSONTokenerWrapper(string)
 		);
-
-		if (map == null)
-			map = new LinkedHashMap<String, Object>();
+		initMap();
 	}
 
 	public JSONObjectWrapper(JSONTokenerWrapper token) {
 		super(token);
-		if (map == null)
-			map = new LinkedHashMap<String, Object>();
+		initMap();
 	}
 
 	public JSONObjectWrapper(Map<?,?> m) {
@@ -48,8 +45,18 @@ public class JSONObjectWrapper extends JSONObject implements java.io.Serializabl
 
 	public JSONObjectWrapper(JSONObject jsonObject) {
 		super(jsonObject.toString());
+		initMap();
+	}
+
+	private void initMap() {
 		if (map == null)
-			map = new LinkedHashMap<String, Object>();
+		{
+			// this is a workaround for the Android implementation not loading the map in the JsonObject constructor
+			if (SpecificImplementation.JsonSerialization != null)
+				map = SpecificImplementation.JsonSerialization.getJSONObjectMap(this);
+			else
+				map = new LinkedHashMap<String, Object>();	
+		}
 	}
 
 	public Set<Entry<String, Object>> entrySet() {


### PR DESCRIPTION
Problem

JsonObjectWrapper  internal map has not values in Android when using GxProperties.

Issue
Error en procedure offline en U12
https://issues.genexus.dev/viewissue?IssueId=203969&TabCode=

Solution

Continue of https://github.com/genexuslabs/JavaClasses/pull/942/

 Fix JsonObjectWrapper to load internal map on constructor if has items in Android.
In Java Json Lib, items are load in contructor via put() method. In android internal has leaves empty and Json lib internal hashmap are only loaded.
So after construtor init internal map of JsonObjectWrapper with Android Specific implementation.