### PR TITLE
The method createNewFile converts all the inputstream to memory. This…

### DIFF
--- a/common/src/main/java/com/genexus/util/GXFileInfo.java
+++ b/common/src/main/java/com/genexus/util/GXFileInfo.java
@@ -68,7 +68,7 @@ public class GXFileInfo implements IGXFileInfo {
 		return fileSource.createNewFile();
 	}
     public boolean createNewFile(InputStream input) throws IOException{
-    	fromBytes(SpecificImplementation.GXutil.toByteArray(input));
+		fromInputStream(input);
 		return true;
 	}
 	public boolean delete(){
@@ -178,6 +178,16 @@ public class GXFileInfo implements IGXFileInfo {
 	{
 		try (OutputStream destination = new BufferedOutputStream(new FileOutputStream(fileSource))) {
 			destination.write(data, 0, data.length);
+		}
+	}
+	private void fromInputStream(InputStream input) throws IOException
+	{
+		try (OutputStream output = new BufferedOutputStream(new FileOutputStream(fileSource))) {
+			byte[] buffer = new byte[8192];
+			int bytesRead;
+			while ((bytesRead = input.read(buffer)) != -1) {
+				output.write(buffer, 0, bytesRead);
+			}
 		}
 	}
 	public String readAllText(String encoding)throws IOException{


### PR DESCRIPTION
… could cause out of memory errors.

Now the process use a buffer to avoid this.
Issue: 205339