### PR TITLE
Add a generic parameter <E> to getExternalInstance

### DIFF
--- a/common/src/main/java/com/genexus/GXExternalCollection.java
+++ b/common/src/main/java/com/genexus/GXExternalCollection.java
@@ -100,7 +100,7 @@ public class GXExternalCollection<T extends GXXMLSerializable> extends GXBaseCol
 	}
 
 	@SuppressWarnings("unchecked")
-	public ArrayList getExternalInstance() {
+	public <E> ArrayList<E> getExternalInstance() {
 		ArrayList list = new ArrayList();
 		for (T Item : this)
 		{


### PR DESCRIPTION
To avoid getting` warning: [unchecked] unchecked cast` when generated code uses this method. So now instead of being declared as

`public ArrayList getExternalInstance()
`
it is declared as

`public <E> ArrayList<E> getExternalInstance()
`
with <E> being the type parameter.
You can then call the method passing an explicit parameter, e.g.:

`chatHistory.<OpenAIResponse.Message>getExternalInstance();
`
which we currently don't generate, but just using

`chatHistory.getExternalInstance();
`
also does not yield a warning.

---------------
Issue: 205291