### PR TITLE
Bump nimbus-jose-jwt from 9.39.2 to 10.4

### DIFF
--- a/securityapicommons/pom.xml
+++ b/securityapicommons/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.39.2</version>
+            <version>10.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Bump nimbus-jose-jwt from 9.39.2 to 10.4 latest available version

CVE-2025-53864

#GXSEC