### PR TITLE
Bump commons-io from version 2.12.0 to  version 2.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<log4j.version>2.21.1</log4j.version>
         <io.opentelemetry.version>1.28.0</io.opentelemetry.version>
         <org.bouncycastle.version>1.78.1</org.bouncycastle.version>
-        <commons-io.version>2.12.0</commons-io.version>
+        <commons-io.version>2.15.1</commons-io.version>
         <commons-codec.version>1.15</commons-codec.version>
         <xmlsec.version>3.0.3</xmlsec.version>
         <jose.version>10.4</jose.version>


### PR DESCRIPTION
Issue:205694

Bump commons-io from version 2.12.0 to  version 2.15.1

CVE-2024-47554

#GXSEC