### PR TITLE
Support for disabling Buffered output response for realtime data streaming (SSE)

### DIFF
--- a/gxweb/src/main/java/com/genexus/webpanels/WebWrapper.java
+++ b/gxweb/src/main/java/com/genexus/webpanels/WebWrapper.java
@@ -40,7 +40,7 @@ public class WebWrapper
 			((HttpContext) context.getHttpContext()).setContext(context);
 			panel.httpContext = (HttpAjaxContext)context.getHttpContext();
 			panel.httpContext.setCompression(false);
-			panel.httpContext.setBuffered(false);
+			panel.httpContext.setResponseBufferMode(HttpContext.ResponseBufferMode.SERVER_DEFAULT);
 			panel.httpContext.useUtf8 = true;
 			panel.httpContext.setOutputStream(new java.io.ByteArrayOutputStream());
 		}

--- a/java/src/main/java/com/genexus/GXWebReport.java
+++ b/java/src/main/java/com/genexus/GXWebReport.java
@@ -33,7 +33,7 @@ public abstract class GXWebReport extends GXWebProcedure
 	{
 		super.initState(context, ui);
 
-		httpContext.setBuffered(true);
+		httpContext.setResponseBufferMode(HttpContext.ResponseBufferMode.ENABLED);
 		httpContext.setBinary(true);
 		String implementation = com.genexus.Application.getClientContext().getClientPreferences().getPDF_RPT_LIBRARY();
 		if (implementation.equals("ITEXT"))

--- a/java/src/main/java/com/genexus/webpanels/GXWebProcedure.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebProcedure.java
@@ -69,16 +69,15 @@ public abstract class GXWebProcedure extends GXObjectBase
 		super.initState(context, ui);
 
 		if(httpContext.getHttpSecure() == 0)httpContext.setHeader("pragma", "no-cache");
-		if (isChunked()) {
-			httpContext.setChunked();
-			httpContext.setCompression(false);
-		}
 
+		if (!isBufferedResponse()) {
+			httpContext.setResponseBufferMode(HttpContext.ResponseBufferMode.DISABLED);
+		}
 		initialize();
 	}
 
-	protected boolean isChunked() {
-		return false;
+	protected boolean isBufferedResponse() {
+		return true;
 	}
 
 	protected void preExecute()

--- a/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
+++ b/java/src/main/java/com/genexus/webpanels/HttpContextWeb.java
@@ -1375,7 +1375,7 @@ public class HttpContextWeb extends HttpContext {
 			if (mustUseWriter()) {
 				setWriter(getResponse().getWriter());
 			} else {
-				if (buffered) {
+				if (bufferMode == ResponseBufferMode.ENABLED) {
 					buffer = new com.genexus.util.FastByteArrayOutputStream();
 					setOutputStream(buffer);
 				} else {
@@ -1386,7 +1386,7 @@ public class HttpContextWeb extends HttpContext {
 					String accepts = getHeader("Accept-Encoding");
 					if (accepts != null && accepts.indexOf("gzip") >= 0) {
 						setHeader("Content-Encoding", "gzip");
-						setOutputStream(new GZIPOutputStream(getOutputStream()));
+						setOutputStream(new GZIPOutputStream(getOutputStream(), true));
 					}
 				}
 			}
@@ -1399,7 +1399,7 @@ public class HttpContextWeb extends HttpContext {
 		proxyCookieValues();
 
 		try {
-			if (buffered) {
+			if (bufferMode == ResponseBufferMode.ENABLED) {
 				// Esto en realidad cierra el ZipOutputStream, o el ByteOutputStream, no cierra
 				// el del
 				// servlet... Es necesario hacerlo, dado que sino el GZip no hace el flush de


### PR DESCRIPTION
- Add support for immediately responses (buffer disabled) through the http response
- Support no buffer responses with compression
- Automatically enable no buffer responses in SSE Responses

Issue: 104684