### PR TITLE
The GAM procedures that call the standard classes to validate the use…

### DIFF
--- a/java/src/main/java/com/genexus/webpanels/GXWebObjectStub.java
+++ b/java/src/main/java/com/genexus/webpanels/GXWebObjectStub.java
@@ -142,6 +142,7 @@ public abstract class GXWebObjectStub extends HttpServlet
 				}
 				ModelContext modelContext = ModelContext.getModelContext(getClass());
 				modelContext.setHttpContext(httpContext);
+				httpContext.setContext(modelContext);
 				ApplicationContext.getInstance().setPoolConnections(!Namespace.createNamespace(modelContext).isRemoteGXDB());
 				String loginObject = Application.getClientContext().getClientPreferences().getProperty("IntegratedSecurityLoginWeb", "");
 				loginObject = GXutil.getClassName(loginObject);


### PR DESCRIPTION
…r could not use anything related to the context, such as reading a variable from an HTTP request, because the request did not have the ModelContext set at the time the proc was called.

Issue: 205865