### PR TITLE
chore: bump version to 4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<url>https://github.com/genexuslabs/JavaClasses</url>
 
 	<properties>
-		<revision>4.12</revision>
+		<revision>4.13</revision>
 		<changelist>-SNAPSHOT</changelist>
 		<sha1/>
 


### PR DESCRIPTION
Bump `revision` to `4.13` following the creation of `release-4.12`.